### PR TITLE
Unittesting import picard data

### DIFF
--- a/trendyqc/trend_monitoring/tests/test_multiqc.py
+++ b/trendyqc/trend_monitoring/tests/test_multiqc.py
@@ -459,6 +459,6 @@ class TestParsingAndImport(TestCase):
                     msg = f"Testing for {sample_id}: {json_field}"
 
                     with self.subTest(msg):
-                        self.assertAlmostEqual(
+                        self.assertEqual(
                             data[json_field], db_data[0].__dict__[db_field]
                         )


### PR DESCRIPTION
- Restructuring of code to separate tests pertaining the MultiQC report object itself and the tests for checking the data
- Test to check the data for Picard alignment summary metrics
- use setUpModule instead of setUpClass for set up of multiqc reports and import in test database