### PR TITLE
In 577 fix import of picard base content

### DIFF
--- a/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
@@ -493,20 +493,31 @@ class MultiQC_report():
                 # if the instances are the type "link_table"
                 if link_table == type_table:
                     model_name = instance._meta.model.__name__.lower()
-                    tool = [tool for tool in self.tools if model_name == tool.subtool]
+                    # check if the tool linked to the model has a subtool i.e.
+                    # a requirement for models that have data divided by lane
+                    # and read
+                    tool_with_subtool = [
+                        tool for tool in self.tools
+                        if model_name == tool.subtool
+                    ]
 
-                    if tool:
-                        tool = tool[0]
+                    if tool_with_subtool:
+                        tool = tool_with_subtool[0]
 
+                        # if the data requires the data to be separated by lane
+                        # and read the tool contains this information and
+                        # requires the creation of 4 distinct instances
                         if tool.divided_by_lane_read:
-                            # the model for linking fastqc data to the sample requires
-                            # 4 instances of the fastqc_read_data model
                             read = instance.sample_read
                             lane = instance.lane
-                            instance_type_tables[f"{tool.parent}_{lane}_{read}"] = instance
+                            instance_type_tables[f"{tool.subtool}_{lane}_{read}"] = instance
 
+                        else:
+                            # i.e. picard_hs_metrics has a picard parent but is
+                            # not separated by lane and read
+                            instance_type_tables[model_name] = instance
                     else:
-                        # i.e. "picard_hs_metrics": picard_hs_metrics instance
+                        # i.e. somalier doesn't have a parent
                         instance_type_tables[model_name] = instance
 
         return instance_type_tables

--- a/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
@@ -163,8 +163,8 @@ class MultiQC_report():
                 # SNP genotyping adds a "sorted" in the sample name
                 sample = sample.replace("_sorted", "")
 
-                # fastqc contains data at the lane and read level
-                if tool_name == "fastqc":
+                # some tools contain data at the lane and read level
+                if tool_obj.divided_by_lane_read:
                     # look for the order, lane and read using regex
                     match = regex.search(
                         r"_(?P<order>S[0-9]+)_(?P<lane>L[0-9]+)_(?P<read>R[12])",
@@ -222,9 +222,9 @@ class MultiQC_report():
                 # convert data in appropriate types for future import
                 cleaned_data = self.clean_data(converted_fields)
 
-                # fastqc needs a new level to take into account the lane and
+                # some tools need a new level to take into account the lane and
                 # the read
-                if tool_name == "fastqc":
+                if tool_obj.divided_by_lane_read:
                     self.data[sample_id][tool_obj].setdefault(lane_read, {})
                     self.data[sample_id][tool_obj][lane_read] = {
                         **self.data[sample_id][tool_obj][lane_read],
@@ -386,16 +386,18 @@ class MultiQC_report():
 
         # check if the tool data has a level for the reads i.e.
         # {read: {field: data, field: data}} vs {field: data, field: data}
-        if all(isinstance(i, dict) for i in tool_data.values()):
+        # if all(isinstance(i, dict) for i in tool_data.values()):
+        if tool_obj.divided_by_lane_read:
             for read, data in tool_data.items():
+                sample_lane, sample_read = read.split("_")
                 # this info is not available in the FastQC data so I create it
                 # myself
-                data["lane"] = read.split("_")[0]
-                data["sample_read"] = read.split("_")[1]
+                data["lane"] = sample_lane
+                data["sample_read"] = sample_read
                 model_instance = model(**data)
                 # store the fastqc instances using their parent table i.e.
                 # fastqc as key
-                self.instances_per_sample["fastqc"].append(model_instance)
+                self.instances_per_sample[tool_obj.parent].append(model_instance)
                 instances_to_return.append(model_instance)
         else:
             model_instance = model(**tool_data)
@@ -491,13 +493,18 @@ class MultiQC_report():
                 # if the instances are the type "link_table"
                 if link_table == type_table:
                     model_name = instance._meta.model.__name__.lower()
+                    tool = [tool for tool in self.tools if model_name == tool.subtool]
 
-                    # the model for linking fastqc data to the sample requires
-                    # 4 instances of the fastqc_read_data model
-                    if type_table == "fastqc":
-                        read = instance.sample_read
-                        lane = instance.lane
-                        instance_type_tables[f"fastqc_{lane}_{read}"] = instance
+                    if tool:
+                        tool = tool[0]
+
+                        if tool.divided_by_lane_read:
+                            # the model for linking fastqc data to the sample requires
+                            # 4 instances of the fastqc_read_data model
+                            read = instance.sample_read
+                            lane = instance.lane
+                            instance_type_tables[f"{tool.parent}_{lane}_{read}"] = instance
+
                     else:
                         # i.e. "picard_hs_metrics": picard_hs_metrics instance
                         instance_type_tables[model_name] = instance

--- a/trendyqc/trend_monitoring/management/commands/utils/_tool.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_tool.py
@@ -30,18 +30,28 @@ class Tool:
         if subtool:
             self.parent = tool_name
 
-        self.config_path = config_dir / "tool_configs" / f"{tool_name}.json"
+        self.config_field_path = config_dir / "tool_configs" / f"{tool_name}.json"
+        self.config_lane_read_path = config_dir / "sample_read_tools.json"
+        self.divided_by_lane_read = False
         self.read_config_data()
 
     def read_config_data(self):
         """ Read in the data in the tool config file """
 
-        fields = json.loads(self.config_path.read_text())
+        fields_config = json.loads(self.config_field_path.read_text())
+        lane_read_config = json.loads(self.config_lane_read_path.read_text())
 
         if self.subtool:
-            self.fields = fields[self.subtool]
+            self.fields = fields_config[self.subtool]
         else:
-            self.fields = fields
+            self.fields = fields_config
+
+        if (
+            self.name in lane_read_config["tools"]
+        ) or (
+            self.subtool in lane_read_config["tools"]
+        ):
+            self.divided_by_lane_read = True
 
     def convert_tool_fields(self, multiqc_data):
         """ Convert the field names from MultiQC to ones that are written in

--- a/trendyqc/trend_monitoring/management/configs/assays.json
+++ b/trendyqc/trend_monitoring/management/configs/assays.json
@@ -1,7 +1,7 @@
 {
     "Myeloid": {
         "multiqc_bcl2fastq_bysample": ["bcl2fastq", null],
-        "multiqc_fastqc": ["fastqc", "read"],
+        "multiqc_fastqc": ["fastqc", "read_data"],
         "multiqc_general_stats": ["custom_coverage", null],
         "multiqc_picard_AlignmentSummaryMetrics": ["picard", "alignment_summary_metrics"],
         "multiqc_picard_HsMetrics": ["picard", "hs_metrics"],
@@ -13,7 +13,7 @@
     },
     "Cancer Endocrine Neurology": {
         "multiqc_bcl2fastq_bysample": ["bcl2fastq", null],
-        "multiqc_fastqc": ["fastqc", "read"],
+        "multiqc_fastqc": ["fastqc", "read_data"],
         "multiqc_happy_indel_data": ["happy", "indel"],
         "multiqc_happy_snp_data": ["happy", "snp"],
         "multiqc_het-hom_analysis": ["vcfqc", null],
@@ -26,7 +26,7 @@
     },
     "Twist WES": {
         "multiqc_bcl2fastq_bysample": ["bcl2fastq", null],
-        "multiqc_fastqc": ["fastqc", "read"],
+        "multiqc_fastqc": ["fastqc", "read_data"],
         "multiqc_happy_indel_data": ["happy", "indel"],
         "multiqc_happy_snp_data": ["happy", "snp"],
         "multiqc_het-hom_analysis": ["vcfqc", null],
@@ -38,10 +38,10 @@
         "multiqc_verifybamid": ["verifybamid", null]
     },
     "TruSight Oncology 500": {
-        "multiqc_fastqc": ["fastqc", "read"]
+        "multiqc_fastqc": ["fastqc", "read_data"]
     },
     "SNP genotyping": {
-        "multiqc_fastqc": ["fastqc", "read"],
+        "multiqc_fastqc": ["fastqc", "read_data"],
         "multiqc_het-hom_analysis": ["vcfqc", null],
         "multiqc_picard_AlignmentSummaryMetrics": ["picard", "alignment_summary_metrics"],
         "multiqc_picard_HsMetrics": ["picard", "hs_metrics"],
@@ -54,7 +54,7 @@
     },
     "TruSight One Expanded": {
         "multiqc_bcl2fastq_bysample": ["bcl2fastq", null],
-        "multiqc_fastqc": ["fastqc", "read"],
+        "multiqc_fastqc": ["fastqc", "read_data"],
         "multiqc_het-hom_analysis": ["vcfqc", null],
         "multiqc_picard_HsMetrics": ["picard", "hs_metrics"],
         "multiqc_picard_dups": ["picard", "duplication_metrics"],
@@ -64,7 +64,7 @@
         "multiqc_verifybamid": ["verifybamid", null]
     },
     "Capture: Familial Hypercholesterolemia (FH)": {
-        "multiqc_fastqc": ["fastqc", "read"],
+        "multiqc_fastqc": ["fastqc", "read_data"],
         "multiqc_happy_indel_data": ["happy", "indel"],
         "multiqc_happy_snp_data": ["happy", "snp"],
         "multiqc_het-hom_analysis": ["vcfqc", null],

--- a/trendyqc/trend_monitoring/management/configs/sample_read_tools.json
+++ b/trendyqc/trend_monitoring/management/configs/sample_read_tools.json
@@ -1,0 +1,3 @@
+{
+    "tools": ["fastqc", "base_distribution_by_cycle_metrics"]
+}

--- a/trendyqc/trend_monitoring/management/configs/tool_configs/fastqc.json
+++ b/trendyqc/trend_monitoring/management/configs/tool_configs/fastqc.json
@@ -1,5 +1,5 @@
 {
-    "read": {
+    "read_data": {
         "File type": "file_type",
         "Encoding": "encoding",
         "Total Sequences": "total_sequences",

--- a/trendyqc/trend_monitoring/models/__init__.py
+++ b/trendyqc/trend_monitoring/models/__init__.py
@@ -3,17 +3,17 @@ from .bam_qc import (
     Samtools_data,
     Custom_coverage,
     Picard,
-    Picard_hs_metrics,
-    Picard_alignment_summary_metrics,
-    Picard_base_distribution_by_cycle_metrics,
-    Picard_gc_bias_metrics,
-    Picard_insert_size_metrics,
-    Picard_quality_yield_metrics,
-    Picard_pcr_metrics
+    HS_metrics,
+    Alignment_summary_metrics,
+    Base_distribution_by_cycle_metrics,
+    GC_bias_metrics,
+    Insert_size_metrics,
+    Quality_yield_metrics,
+    PCR_metrics
 )
 from .fastq_qc import (
     Fastqc,
-    Fastqc_read_data,
+    Read_data,
     Bcl2fastq_data
 )
 from .metadata import (

--- a/trendyqc/trend_monitoring/models/bam_qc.py
+++ b/trendyqc/trend_monitoring/models/bam_qc.py
@@ -78,38 +78,47 @@ class Custom_coverage(models.Model):
 
 
 class Picard(models.Model):
-    sample = models.CharField(max_length=10)
-    library = models.CharField(max_length=10)
-    read_group = models.CharField(max_length=10)
-    picard_hs_metrics = models.ForeignKey(
-        "Picard_hs_metrics", on_delete=models.DO_NOTHING, blank=True, null=True
+    hs_metrics = models.ForeignKey(
+        "HS_metrics", on_delete=models.DO_NOTHING, blank=True, null=True
     )
-    picard_alignment_summary_metrics = models.ForeignKey(
-        "Picard_alignment_summary_metrics", on_delete=models.DO_NOTHING,
+    alignment_summary_metrics = models.ForeignKey(
+        "Alignment_summary_metrics", on_delete=models.DO_NOTHING,
         blank=True, null=True
     )
-    picard_base_distribution_by_cycle_metrics = models.ForeignKey(
-        "Picard_base_distribution_by_cycle_metrics",
+    base_distribution_by_cycle_metrics_L001_R1 = models.ForeignKey(
+        "Base_distribution_by_cycle_metrics", related_name="base_distribution_by_cycle_metrics_L001_R1",
         on_delete=models.DO_NOTHING, blank=True, null=True
     )
-    picard_gc_bias_metrics = models.ForeignKey(
-        "Picard_gc_bias_metrics", on_delete=models.DO_NOTHING, blank=True,
+    base_distribution_by_cycle_metrics_L001_R2 = models.ForeignKey(
+        "Base_distribution_by_cycle_metrics", related_name="base_distribution_by_cycle_metrics_L001_R2",
+        on_delete=models.DO_NOTHING, blank=True, null=True
+    )
+    base_distribution_by_cycle_metrics_L002_R1 = models.ForeignKey(
+        "Base_distribution_by_cycle_metrics", related_name="base_distribution_by_cycle_metrics_L002_R1",
+        on_delete=models.DO_NOTHING, blank=True, null=True
+    )
+    base_distribution_by_cycle_metrics_L002_R2 = models.ForeignKey(
+        "Base_distribution_by_cycle_metrics", related_name="base_distribution_by_cycle_metrics_L002_R2",
+        on_delete=models.DO_NOTHING, blank=True, null=True
+    )
+    gc_bias_metrics = models.ForeignKey(
+        "GC_bias_metrics", on_delete=models.DO_NOTHING, blank=True,
         null=True
     )
-    picard_insert_size_metrics = models.ForeignKey(
-        "Picard_insert_size_metrics", on_delete=models.DO_NOTHING, blank=True,
+    insert_size_metrics = models.ForeignKey(
+        "Insert_size_metrics", on_delete=models.DO_NOTHING, blank=True,
         null=True
     )
-    picard_quality_yield_metrics = models.ForeignKey(
-        "Picard_quality_yield_metrics", on_delete=models.DO_NOTHING,
+    quality_yield_metrics = models.ForeignKey(
+        "Quality_yield_metrics", on_delete=models.DO_NOTHING,
         blank=True, null=True
     )
-    picard_pcr_metrics = models.ForeignKey(
-        "Picard_pcr_metrics", on_delete=models.DO_NOTHING, blank=True,
+    pcr_metrics = models.ForeignKey(
+        "PCR_metrics", on_delete=models.DO_NOTHING, blank=True,
         null=True
     )
-    picard_duplication_metrics = models.ForeignKey(
-        "Picard_duplication_metrics", on_delete=models.DO_NOTHING, blank=True,
+    duplication_metrics = models.ForeignKey(
+        "Duplication_metrics", on_delete=models.DO_NOTHING, blank=True,
         null=True
     )
 
@@ -118,7 +127,7 @@ class Picard(models.Model):
         db_table = "picard"
 
 
-class Picard_hs_metrics(models.Model):
+class HS_metrics(models.Model):
     bait_set = models.CharField(max_length=10)
     bait_territory = models.FloatField()
     bait_design_efficiency = models.FloatField()
@@ -179,10 +188,10 @@ class Picard_hs_metrics(models.Model):
 
     class Meta:
         app_label = "trend_monitoring"
-        db_table = "picard_hs_metrics"
+        db_table = "hs_metrics"
 
 
-class Picard_alignment_summary_metrics(models.Model):
+class Alignment_summary_metrics(models.Model):
     category = models.CharField(max_length=10)
     total_reads = models.FloatField()
     pf_reads = models.FloatField()
@@ -210,10 +219,12 @@ class Picard_alignment_summary_metrics(models.Model):
 
     class Meta:
         app_label = "trend_monitoring"
-        db_table = "picard_alignment_summary_metrics"
+        db_table = "alignment_summary_metrics"
 
 
-class Picard_base_distribution_by_cycle_metrics(models.Model):
+class Base_distribution_by_cycle_metrics(models.Model):
+    lane = models.CharField(max_length=20)
+    sample_read = models.CharField(max_length=20)
     sum_pct_a = models.FloatField()
     sum_pct_c = models.FloatField()
     sum_pct_g = models.FloatField()
@@ -227,10 +238,10 @@ class Picard_base_distribution_by_cycle_metrics(models.Model):
 
     class Meta:
         app_label = "trend_monitoring"
-        db_table = "picard_base_distribution_by_cycle_metrics"
+        db_table = "base_distribution_by_cycle_metrics"
 
 
-class Picard_gc_bias_metrics(models.Model):
+class GC_bias_metrics(models.Model):
     accumulation_level = models.CharField(max_length=20)
     reads_used = models.CharField(max_length=10)
     window_size = models.IntegerField()
@@ -246,10 +257,10 @@ class Picard_gc_bias_metrics(models.Model):
 
     class Meta:
         app_label = "trend_monitoring"
-        db_table = "picard_gc_bias_metrics"
+        db_table = "gc_bias_metrics"
 
 
-class Picard_insert_size_metrics(models.Model):
+class Insert_size_metrics(models.Model):
     median_insert_size = models.FloatField()
     mode_insert_size = models.FloatField(null=True)
     median_absolute_deviation = models.FloatField()
@@ -272,10 +283,10 @@ class Picard_insert_size_metrics(models.Model):
 
     class Meta:
         app_label = "trend_monitoring"
-        db_table = "picard_insert_size_metrics"
+        db_table = "insert_size_metrics"
 
 
-class Picard_quality_yield_metrics(models.Model):
+class Quality_yield_metrics(models.Model):
     total_reads = models.IntegerField()
     pf_reads = models.IntegerField()
     read_length = models.IntegerField()
@@ -290,10 +301,10 @@ class Picard_quality_yield_metrics(models.Model):
 
     class Meta:
         app_label = "trend_monitoring"
-        db_table = "picard_quality_yield_metrics"
+        db_table = "quality_yield_metrics"
 
 
-class Picard_pcr_metrics(models.Model):
+class PCR_metrics(models.Model):
     custom_amplicon_set = models.CharField(max_length=20)
     amplicon_territory = models.FloatField()
     on_amplicon_bases = models.FloatField()
@@ -347,10 +358,10 @@ class Picard_pcr_metrics(models.Model):
 
     class Meta:
         app_label = "trend_monitoring"
-        db_table = "picard_pcr_metrics"
+        db_table = "pcr_metrics"
 
 
-class Picard_duplication_metrics(models.Model):
+class Duplication_metrics(models.Model):
     unpaired_reads_examined = models.FloatField()
     read_pairs_examined = models.FloatField()
     secondary_or_suplementary_rds = models.FloatField()
@@ -370,4 +381,4 @@ class Picard_duplication_metrics(models.Model):
 
     class Meta:
         app_label = "trend_monitoring"
-        db_table = "picard_duplication_metrics"
+        db_table = "duplication_metrics"

--- a/trendyqc/trend_monitoring/models/fastq_qc.py
+++ b/trendyqc/trend_monitoring/models/fastq_qc.py
@@ -2,13 +2,13 @@ from django.db import models
 
 
 class Fastqc(models.Model):
-    fastqc_L001_R1 = models.ForeignKey("Fastqc_read_data", on_delete=models.DO_NOTHING, related_name="fastqc_L001_R1")
-    fastqc_L001_R2 = models.ForeignKey("Fastqc_read_data", on_delete=models.DO_NOTHING, related_name="fastqc_L001_R2")
-    fastqc_L002_R1 = models.ForeignKey("Fastqc_read_data", on_delete=models.DO_NOTHING, related_name="fastqc_L002_R1", blank=True, null=True)
-    fastqc_L002_R2 = models.ForeignKey("Fastqc_read_data", on_delete=models.DO_NOTHING, related_name="fastqc_L002_R2", blank=True, null=True)
+    read_data_L001_R1 = models.ForeignKey("Read_data", on_delete=models.DO_NOTHING, related_name="read_data_L001_R1")
+    read_data_L001_R2 = models.ForeignKey("Read_data", on_delete=models.DO_NOTHING, related_name="read_data_L001_R2")
+    read_data_L002_R1 = models.ForeignKey("Read_data", on_delete=models.DO_NOTHING, related_name="read_data_L002_R1", blank=True, null=True)
+    read_data_L002_R2 = models.ForeignKey("Read_data", on_delete=models.DO_NOTHING, related_name="read_data_L002_R2", blank=True, null=True)
 
 
-class Fastqc_read_data(models.Model):
+class Read_data(models.Model):
     sample_read = models.CharField(max_length=50, blank=True)
     lane = models.CharField(max_length=20, blank=True)
     file_type = models.CharField(max_length=50)

--- a/trendyqc/trend_monitoring/tests/test_data/tools.json
+++ b/trendyqc/trend_monitoring/tests/test_data/tools.json
@@ -4,7 +4,7 @@
         {"total": "total", "total_yield": "total_yield", "perfectIndex": "perfect_index", "yieldQ30": "yield_Q30", "qscore_sum": "qscore_sum", "R1_yield": "r1_yield", "R1_Q30": "r1_Q30", "R1_trimmed_bases": "r1_trimmed_bases", "R2_yield": "r2_yield", "R2_Q30": "r2_Q30", "R2_trimmed_bases": "r2_trimmed_bases", "percent_Q30": "pct_Q30", "percent_perfectIndex": "pct_perfect_index", "mean_qscore": "mean_qscore"}
     ],
     "fastqc": [
-        {"tool_name": "fastqc", "multiqc_field": "multiqc_fastqc", "subtool": "read"},
+        {"tool_name": "fastqc", "multiqc_field": "multiqc_fastqc", "subtool": "read_data"},
         {"File type": "file_type", "Encoding": "encoding", "Total Sequences": "total_sequences", "Sequences flagged as poor quality": "sequences_flagged_as_poor_quality", "Sequence length": "sequence_length", "%GC": "gc_pct", "total_deduplicated_percentage": "total_deduplicated_pct", "avg_sequence_length": "avg_sequence_length", "basic_statistics": "basic_statistics", "per_base_sequence_quality": "per_base_sequence_quality", "per_tile_sequence_quality": "per_tile_sequence_quality", "per_sequence_quality_scores": "per_sequence_quality_scores", "per_base_sequence_content": "per_base_sequence_content", "per_sequence_gc_content": "per_sequence_gc_content", "per_base_n_content": "per_base_n_content", "sequence_length_distribution": "sequence_length_distribution", "sequence_duplication_levels": "sequence_duplication_levels", "overrepresented_sequences": "overrepresented_sequences", "adapter_content": "adapter_content"}
     ],
     "custom_coverage": [

--- a/trendyqc/trend_monitoring/tests/test_multiqc.py
+++ b/trendyqc/trend_monitoring/tests/test_multiqc.py
@@ -11,21 +11,21 @@ from trend_monitoring.models.metadata import (
     Report, Patient, Report_Sample, Sample
 )
 from trend_monitoring.models.fastq_qc import (
-    Fastqc_read_data, Fastqc, Bcl2fastq_data
+    Read_data, Fastqc, Bcl2fastq_data
 )
 from trend_monitoring.models.bam_qc import (
     VerifyBAMid_data,
     Samtools_data,
     Custom_coverage,
     Picard,
-    Picard_alignment_summary_metrics,
-    Picard_base_distribution_by_cycle_metrics,
-    Picard_duplication_metrics,
-    Picard_gc_bias_metrics,
-    Picard_hs_metrics,
-    Picard_insert_size_metrics,
-    Picard_pcr_metrics,
-    Picard_quality_yield_metrics,
+    Alignment_summary_metrics,
+    Base_distribution_by_cycle_metrics,
+    Duplication_metrics,
+    GC_bias_metrics,
+    HS_metrics,
+    Insert_size_metrics,
+    PCR_metrics,
+    Quality_yield_metrics,
 )
 from trend_monitoring.models.vcf_qc import (
     Somalier_data,
@@ -317,8 +317,8 @@ class TestParsingAndImport(TestCase, CustomTests):
         # SNP genotyping adds a "sorted" in the sample name
         sample = sample.replace("_sorted", "")
 
-        # fastqc contains data at the lane and read level
-        if tool_name == "fastqc":
+        # some tools contains data at the lane and read level
+        if tool_name == "fastqc" or tool_name == "picard_base_content":
             # look for the order, lane and read using regex
             match = re.search(
                 r"_(?P<order>S[0-9]+)_(?P<lane>L[0-9]+)_(?P<read>R[12])",
@@ -483,10 +483,8 @@ class TestParsingAndImport(TestCase, CustomTests):
                     filter_dict, template_dict
                 )
 
-                # look for the fastqc read data object (should be unique)
+                # look for the data with the built filter dict
                 db_data = model.objects.filter(**dynamic_filter_dict)
-                # in this dict, key = field name in json / value = field name
-                # in db model
 
                 msg = (
                     f"Couldn't find data or unique data for {sample_id} "
@@ -550,9 +548,9 @@ class TestParsingAndImport(TestCase, CustomTests):
         filter_dict = {
             "sample_read": "{read}",
             "lane": "{lane}",
-            "fastqc_{lane}_{read}__report_sample__sample__sample_id": "{sample_id}"
+            "read_data_{lane}_{read}__report_sample__sample__sample_id": "{sample_id}"
         }
-        model = Fastqc_read_data
+        model = Read_data
 
         for msg, db_field, json_data, db_data in self._get_data_for(
             tool_name, filter_dict, model
@@ -574,7 +572,7 @@ class TestParsingAndImport(TestCase, CustomTests):
         filter_dict = {
             "picard__report_sample__sample__sample_id": "{sample_id}"
         }
-        model = Picard_alignment_summary_metrics
+        model = Alignment_summary_metrics
 
         for msg, db_field, json_data, db_data in self._get_data_for(
             tool_name, filter_dict, model
@@ -600,7 +598,7 @@ class TestParsingAndImport(TestCase, CustomTests):
         filter_dict = {
             "picard__report_sample__sample__sample_id": "{sample_id}"
         }
-        model = Picard_hs_metrics
+        model = HS_metrics
 
         for msg, db_field, json_data, db_data in self._get_data_for(
             tool_name, filter_dict, model
@@ -621,7 +619,7 @@ class TestParsingAndImport(TestCase, CustomTests):
         filter_dict = {
             "picard__report_sample__sample__sample_id": "{sample_id}"
         }
-        model = Picard_insert_size_metrics
+        model = Insert_size_metrics
 
         for msg, db_field, json_data, db_data in self._get_data_for(
             tool_name, filter_dict, model
@@ -914,7 +912,7 @@ class TestParsingAndImport(TestCase, CustomTests):
         filter_dict = {
             "picard__report_sample__sample__sample_id": "{sample_id}",
         }
-        model = Picard_alignment_summary_metrics
+        model = Alignment_summary_metrics
 
         for msg, db_field, json_data, db_data in self._get_data_for(
             tool_name, filter_dict, model
@@ -936,7 +934,7 @@ class TestParsingAndImport(TestCase, CustomTests):
         filter_dict = {
             "picard__report_sample__sample__sample_id": "{sample_id}",
         }
-        model = Picard_insert_size_metrics
+        model = Insert_size_metrics
 
         for msg, db_field, json_data, db_data in self._get_data_for(
             tool_name, filter_dict, model


### PR DESCRIPTION
- make the separation by lane and read data more tool agnostic
    - new config file to inform which tools are lane and read separated
    - added a bool attribute in tool objects
    - have a "framework" to dynamically create Django queries to get the sample id from the model containing the data: `f"{tool.name}_{lane}_{read}"`
    - updated model names to match the framework
    - updated configs to match new model names
    - updated tests to match new model names

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/trendyQC/82)
<!-- Reviewable:end -->
