### PR TITLE
In 588 fix import of multiple lane for tools that separate their data by lane

### DIFF
--- a/trendyqc/trend_monitoring/management/commands/add_projects.py
+++ b/trendyqc/trend_monitoring/management/commands/add_projects.py
@@ -99,7 +99,7 @@ class Command(BaseCommand):
             for report in setup_report_object(project_id):
                 if not options["dry_run"]:
                     import_multiqc_report(report)
-                    imported_reports.append(report)
+                    imported_reports.append(report.multiqc_json_id)
 
         if is_automated_update:
             now = datetime.datetime.now().strftime("%y%m%d|%I:%M")

--- a/trendyqc/trend_monitoring/management/commands/add_projects.py
+++ b/trendyqc/trend_monitoring/management/commands/add_projects.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand
 import regex
 
 from .utils._dnanexus_utils import login_to_dnanexus, get_002_projects
-from .utils._report import setup_report_objects, import_multiqc_reports
+from .utils._report import setup_report_object, import_multiqc_report
 
 logger = logging.getLogger("basic")
 storing_logger = logging.getLogger("storing")
@@ -37,8 +37,8 @@ class Command(BaseCommand):
             help="Scan all 002 projects to import all MultiQC reports"
         )
         parser.add_argument(
-            "-update", "--automated_update", action="store_true", default=False,
-            help=(
+            "-update", "--automated_update", action="store_true",
+            default=False, help=(
                 "Flag to indicate whether this was launched by an automated "
                 "job"
             )
@@ -93,10 +93,13 @@ class Command(BaseCommand):
             logger.error(msg)
             raise AssertionError(msg)
 
-        reports = setup_report_objects(project_ids)
+        imported_reports = []
 
-        if not options["dry_run"]:
-            imported_reports = import_multiqc_reports(reports)
+        for project_id in project_ids:
+            for report in setup_report_object(project_id):
+                if not options["dry_run"]:
+                    import_multiqc_report(report)
+                    imported_reports.append(report)
 
         if is_automated_update:
             now = datetime.datetime.now().strftime("%y%m%d|%I:%M")

--- a/trendyqc/trend_monitoring/management/commands/add_projects.py
+++ b/trendyqc/trend_monitoring/management/commands/add_projects.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
         logger.info(f"Command line: {' '.join(sys.argv)}")
 
         is_automated_update = options["automated_update"]
-        
+
         if is_automated_update:
             now = datetime.datetime.now().strftime("%y%m%d|%I:%M")
             print(f"Starting update at {now}: {' '.join(sys.argv)}")

--- a/trendyqc/trend_monitoring/management/commands/utils/_dnanexus_utils.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_dnanexus_utils.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from ._notifications import slack_notify
 
 
-def login_to_dnanexus():
+def login_to_dnanexus(verbose=False):
     """ Login to DNAnexus using a auth token present in the environment """
 
     DX_SECURITY_CONTEXT = {
@@ -20,7 +20,10 @@ def login_to_dnanexus():
 
     try:
         dxpy.whoami()
-        print("DNAnexus login successful")
+
+        if verbose:
+            print("DNAnexus login successful")
+
     except Exception:
         traceback.print_exc()
         msg = (

--- a/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
@@ -11,6 +11,7 @@ import regex
 from django.apps import apps
 from django.db import transaction
 from django.db.models import Model
+from django.db.utils import IntegrityError
 from django.utils import timezone
 
 from ._check import already_in_db
@@ -26,65 +27,65 @@ logger = logging.getLogger("basic")
 
 
 class MultiQC_report():
-    def __init__(
-        self,
-        multiqc_report_id: str,
-        multiqc_project_id: str,
-        multiqc_job_id: str,
-        data: str
-    ) -> None:
+    def __init__(self, **kwargs) -> None:
         """ Initialize MultiQC report
 
         Args:
-            multiqc_report_id (str): DNAnexus file id for MultiQC report data
-            multiqc_project_id (str): DNAnexus project id for MultiQC report
-            data
-            multiqc_job_id (str): DNAnexus job id for MultiQC report data
-            data (str): Content of MultiQC report data
+            Expected kwargs are:
+            - multiqc_report_id: DNAnexus multiqc report id
+            - multiqc_project_id: DNAnexus project id of report
+            - multiqc_job_id: DNAnexus multiqc job id
+            - data: Data contained in the MultiQC json file
         """
 
-        self.project_id = multiqc_project_id
-        self.multiqc_json_id = multiqc_report_id
-        self.job_id = multiqc_job_id
+        self.multiqc_json_id = kwargs.get("multiqc_report_id", None)
+        self.project_id = kwargs.get("multiqc_project_id", None)
+        self.job_id = kwargs.get("multiqc_job_id", None)
+        data = kwargs.get("data", None)
 
-        self.original_data = json.loads(data)
-        self.assay = self.original_data.get("config_subtitle", None)
-        self.is_importable = True
-        # Store the Django models as a dict of model names to model objects
-        self.models = {
-            model.__name__.lower(): model for model in apps.get_models()
-        }
+        if not all([self.multiqc_json_id, self.project_id, self.job_id, data]):
+            self.is_importable = False
+        else:
+            self.original_data = json.loads(data)
+            self.assay = self.original_data.get("config_subtitle", None)
+            self.is_importable = True
+            # Store the Django models as a dict of model names to model objects
+            self.models = {
+                model.__name__.lower(): model for model in apps.get_models()
+            }
 
-        # skip projects for which we don't have a config subtitle
-        if self.assay:
-            # load the report's assay tools and the fields they are associated
-            # with
-            self.assay_data = load_assay_config(self.assay, CONFIG_DIR)
-            self.get_metadata()
-
-            if already_in_db(
-                self.models["report"], dnanexus_file_id=self.multiqc_json_id,
-                name=self.report_name
-            ):
+            # skip projects for which we don't have a config subtitle
+            if not self.assay:
                 self.is_importable = False
                 logger.warning((
-                    f"{self.multiqc_json_id} has already been imported in the "
-                    "database. Skipping.."
+                    f"{self.multiqc_json_id}: the gathered assay name in "
+                    "the MultiQC JSON ('config_subtitle') is not present in "
+                    "the trendyqc/trend_monitoring/management/configs/assays.json. "
+                    "Skipping.."
                 ))
             else:
-                self.setup_tools()
-                self.map_models_to_tools()
-                self.parse_multiqc_report()
-                self.data = clean_sample_naming(self.data)
-                self.create_all_instances()
-        else:
-            self.is_importable = False
-            logger.warning((
-                f"{self.multiqc_json_id}: the gathered assay name in "
-                "the MultiQC JSON ('config_subtitle') is not present in the "
-                "trendyqc/trend_monitoring/management/configs/assays.json. "
-                "Skipping.."
-            ))
+                # load the report's assay tools and the fields they are
+                # associated with
+                self.assay_data = load_assay_config(self.assay, CONFIG_DIR)
+                self.get_metadata()
+
+                # check if the report is already in the database
+                if already_in_db(
+                    self.models["report"], name=self.report_name,
+                    dnanexus_file_id=self.multiqc_json_id
+                ):
+                    self.is_importable = False
+                    logger.warning((
+                        f"{self.multiqc_json_id} has already been imported in "
+                        "the database. Skipping.."
+                    ))
+
+        if self.is_importable:
+            self.setup_tools()
+            self.map_models_to_tools()
+            self.parse_multiqc_report()
+            self.data = clean_sample_naming(self.data)
+            self.create_all_instances()
 
     def setup_tools(self):
         """ Create tools for use when parsing the MultiQC data and store them
@@ -544,4 +545,11 @@ class MultiQC_report():
 
         for sample, instances in self.all_instances.items():
             for instance in instances:
-                instance.save()
+                try:
+                    instance.save()
+                except IntegrityError as e:
+                    instance_model_name = type(instance).__name__
+                    logger.error(
+                        f"{self.multiqc_json_id} could not be imported "
+                        f"because of {instance_model_name}:\n{e}"
+                    )

--- a/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
@@ -525,7 +525,6 @@ class MultiQC_report():
 
             # check if lane and read info has been detected and added
             if lane_instances:
-                # print(lane_instances)
                 # order the lanes for addition
                 ordered_lanes = sorted(lane_instances)
 

--- a/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_multiqc.py
@@ -525,6 +525,11 @@ class MultiQC_report():
 
             # check if lane and read info has been detected and added
             if lane_instances:
+                if len(lane_instances) > 2:
+                    logger.warning(
+                        f"{self.multiqc_json_id} contains more than 2 lanes"
+                    )
+
                 # order the lanes for addition
                 ordered_lanes = sorted(lane_instances)
 

--- a/trendyqc/trend_monitoring/management/commands/utils/_notifications.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_notifications.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from django.conf import settings
 

--- a/trendyqc/trend_monitoring/management/commands/utils/_utils.py
+++ b/trendyqc/trend_monitoring/management/commands/utils/_utils.py
@@ -7,6 +7,7 @@ from typing import Any
 
 error_logger = logging.getLogger("error")
 
+
 def clean_value(value: str) -> Any:
     """ Determine if the value needs its type changed because for example,
     Happy returns strings for this numbers. Additionally, return None if an

--- a/trendyqc/trend_monitoring/management/configs/tool_configs/custom_coverage.json
+++ b/trendyqc/trend_monitoring/management/configs/tool_configs/custom_coverage.json
@@ -1,6 +1,8 @@
 {
     "custom_coverage_mqc-generalstats-custom_coverage-1000x": "cov_1000x",
     "custom_coverage_mqc-generalstats-custom_coverage-250x": "cov_250x",
+    "custom_coverage_mqc-generalstats-custom_coverage-300x": "cov_300x",
+    "custom_coverage_mqc-generalstats-custom_coverage-200x": "cov_200x",
     "custom_coverage_mqc-generalstats-custom_coverage-500x": "cov_500x",
     "custom_coverage_mqc-generalstats-custom_coverage-Usable_unique_bases_on_target": "usable_unique_bases_on_target"
 }

--- a/trendyqc/trend_monitoring/models/bam_qc.py
+++ b/trendyqc/trend_monitoring/models/bam_qc.py
@@ -67,10 +67,12 @@ class Samtools_data(models.Model):
 
 
 class Custom_coverage(models.Model):
-    cov_250x = models.FloatField()
-    cov_500x = models.FloatField()
-    cov_1000x = models.FloatField()
-    usable_unique_bases_on_target = models.FloatField()
+    cov_200x = models.FloatField(null=True)
+    cov_250x = models.FloatField(null=True)
+    cov_300x = models.FloatField(null=True)
+    cov_500x = models.FloatField(null=True)
+    cov_1000x = models.FloatField(null=True)
+    usable_unique_bases_on_target = models.FloatField(null=True)
 
     class Meta:
         app_label = "trend_monitoring"

--- a/trendyqc/trend_monitoring/models/bam_qc.py
+++ b/trendyqc/trend_monitoring/models/bam_qc.py
@@ -85,20 +85,24 @@ class Picard(models.Model):
         "Alignment_summary_metrics", on_delete=models.DO_NOTHING,
         blank=True, null=True
     )
-    base_distribution_by_cycle_metrics_L001_R1 = models.ForeignKey(
-        "Base_distribution_by_cycle_metrics", related_name="base_distribution_by_cycle_metrics_L001_R1",
+    base_distribution_by_cycle_metrics_1st_lane_R1 = models.ForeignKey(
+        "Base_distribution_by_cycle_metrics",
+        related_name="base_distribution_by_cycle_metrics_1st_lane_R1",
         on_delete=models.DO_NOTHING, blank=True, null=True
     )
-    base_distribution_by_cycle_metrics_L001_R2 = models.ForeignKey(
-        "Base_distribution_by_cycle_metrics", related_name="base_distribution_by_cycle_metrics_L001_R2",
+    base_distribution_by_cycle_metrics_1st_lane_R2 = models.ForeignKey(
+        "Base_distribution_by_cycle_metrics",
+        related_name="base_distribution_by_cycle_metrics_1st_lane_R2",
         on_delete=models.DO_NOTHING, blank=True, null=True
     )
-    base_distribution_by_cycle_metrics_L002_R1 = models.ForeignKey(
-        "Base_distribution_by_cycle_metrics", related_name="base_distribution_by_cycle_metrics_L002_R1",
+    base_distribution_by_cycle_metrics_2st_lane_R1 = models.ForeignKey(
+        "Base_distribution_by_cycle_metrics",
+        related_name="base_distribution_by_cycle_metrics_2st_lane_R1",
         on_delete=models.DO_NOTHING, blank=True, null=True
     )
-    base_distribution_by_cycle_metrics_L002_R2 = models.ForeignKey(
-        "Base_distribution_by_cycle_metrics", related_name="base_distribution_by_cycle_metrics_L002_R2",
+    base_distribution_by_cycle_metrics_2st_lane_R2 = models.ForeignKey(
+        "Base_distribution_by_cycle_metrics",
+        related_name="base_distribution_by_cycle_metrics_2st_lane_R2",
         on_delete=models.DO_NOTHING, blank=True, null=True
     )
     gc_bias_metrics = models.ForeignKey(

--- a/trendyqc/trend_monitoring/models/fastq_qc.py
+++ b/trendyqc/trend_monitoring/models/fastq_qc.py
@@ -2,10 +2,22 @@ from django.db import models
 
 
 class Fastqc(models.Model):
-    read_data_L001_R1 = models.ForeignKey("Read_data", on_delete=models.DO_NOTHING, related_name="read_data_L001_R1")
-    read_data_L001_R2 = models.ForeignKey("Read_data", on_delete=models.DO_NOTHING, related_name="read_data_L001_R2")
-    read_data_L002_R1 = models.ForeignKey("Read_data", on_delete=models.DO_NOTHING, related_name="read_data_L002_R1", blank=True, null=True)
-    read_data_L002_R2 = models.ForeignKey("Read_data", on_delete=models.DO_NOTHING, related_name="read_data_L002_R2", blank=True, null=True)
+    read_data_1st_lane_R1 = models.ForeignKey(
+        "Read_data", on_delete=models.DO_NOTHING,
+        related_name="read_data_1st_lane_R1"
+    )
+    read_data_1st_lane_R2 = models.ForeignKey(
+        "Read_data", on_delete=models.DO_NOTHING,
+        related_name="read_data_1st_lane_R2"
+    )
+    read_data_2nd_lane_R1 = models.ForeignKey(
+        "Read_data", on_delete=models.DO_NOTHING,
+        related_name="read_data_2nd_lane_R1", blank=True, null=True
+    )
+    read_data_2nd_lane_R2 = models.ForeignKey(
+        "Read_data", on_delete=models.DO_NOTHING,
+        related_name="read_data_2nd_lane_R2", blank=True, null=True
+    )
 
 
 class Read_data(models.Model):

--- a/trendyqc/trend_monitoring/tests/test_data/tools.json
+++ b/trendyqc/trend_monitoring/tests/test_data/tools.json
@@ -9,7 +9,7 @@
     ],
     "custom_coverage": [
         {"tool_name": "custom_coverage", "multiqc_field": "multiqc_general_stats", "subtool": null},
-        {"custom_coverage_mqc-generalstats-custom_coverage-1000x": "cov_1000x", "custom_coverage_mqc-generalstats-custom_coverage-250x": "cov_250x", "custom_coverage_mqc-generalstats-custom_coverage-500x": "cov_500x", "custom_coverage_mqc-generalstats-custom_coverage-Usable_unique_bases_on_target": "usable_unique_bases_on_target"}
+        {"custom_coverage_mqc-generalstats-custom_coverage-1000x": "cov_1000x", "custom_coverage_mqc-generalstats-custom_coverage-250x": "cov_250x", "custom_coverage_mqc-generalstats-custom_coverage-500x": "cov_500x", "custom_coverage_mqc-generalstats-custom_coverage-300x": "cov_300x", "custom_coverage_mqc-generalstats-custom_coverage-200x": "cov_200x", "custom_coverage_mqc-generalstats-custom_coverage-Usable_unique_bases_on_target": "usable_unique_bases_on_target"}
     ],
     "happy_indel": [
         {"tool_name": "happy", "multiqc_field": "multiqc_happy_indel_data", "subtool": "indel"},


### PR DESCRIPTION
- Fix issue where lane assignment could be other than L001 + L002
    - Introduce system to assign lane number to a `1st` or `2nd` lane number
    - Rename fields in Picard to match new system
- Make functions for setting up and import reports, units
- Rewrite the init for MultiQC reports
- New fields for Custom coverage
- Adjust tests to match changes
```
python trendyqc/manage.py test trend_monitoring.tests
Found 30 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..............................
----------------------------------------------------------------------
Ran 30 tests in 65.637s

OK
Destroying test database for alias 'default'...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/trendyQC/90)
<!-- Reviewable:end -->
