### PR TITLE
In 644 fix plotting following lane changes

### DIFF
--- a/trendyqc/trend_monitoring/backend_utils/filtering.py
+++ b/trendyqc/trend_monitoring/backend_utils/filtering.py
@@ -8,7 +8,7 @@ from trend_monitoring.models.filters import Filter
 
 
 def import_filter(filter_name: str, username: str, data: dict) -> str:
-    """ Import filter data 
+    """ Import filter data
 
     Args:
         filter_name (str): Name of the filter
@@ -57,4 +57,4 @@ def serialize_date(obj):
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
 
-    raise TypeError (f"Type {type(obj)} not serializable")
+    raise TypeError(f"Type {type(obj)} not serializable")

--- a/trendyqc/trend_monitoring/backend_utils/plot.py
+++ b/trendyqc/trend_monitoring/backend_utils/plot.py
@@ -382,7 +382,6 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
                     project_name=project_name,
                     name="First lane",
                     visible="legendonly",
-                    hovertext=first_lane,
                     lane=first_lane,
                     boxplot_color="AED6F1",
                     boxplot_line_color="000000",
@@ -397,7 +396,6 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
                     name="Second lane",
                     visible="legendonly",
                     lane=second_lane,
-                    hovertext=second_lane,
                     boxplot_color="F1948A",
                     boxplot_line_color="000000",
                     showlegend=shown_legend
@@ -457,12 +455,20 @@ def create_trace(data, data_column, **kwargs):
         for value in sub_df[data_column].values
     ]
 
-    if kwargs.get("lane", None):
-        legend_group = f"{kwargs['name']} | {kwargs.get('lane')}"
-    else:
-        legend_group = kwargs['name']
-
     date = get_date_from_project_name(kwargs["project_name"])
+
+    if kwargs.get("lane", None):
+        lane_info = kwargs['lane']
+    else:
+        lane_info = ""
+
+    text_data = []
+
+    for ele in list(sub_df["sample_id"].values):
+        if lane_info:
+            text_data.append(f"{ele} - {lane_info}")
+        else:
+            text_data.append(ele)
 
     # setup each boxplot with the appropriate annotation and data points
     trace = {
@@ -472,7 +478,7 @@ def create_trace(data, data_column, **kwargs):
         "y": data_values,
         "name": kwargs["name"],
         "type": "box",
-        "text": list(sub_df["sample_id"].values),
+        "text": text_data,
         "boxpoints": "suspectedoutliers",
         "marker": {
             "color": kwargs["boxplot_color"],
@@ -480,9 +486,10 @@ def create_trace(data, data_column, **kwargs):
         "line": {
             "color": kwargs.get("boxplot_line_color", "#444")
         },
+        # +80 adds transparency
         "fillcolor": kwargs["boxplot_color"]+"80",
         "offsetgroup": kwargs["name"],
-        "legendgroup": legend_group,
+        "legendgroup": kwargs["name"],
         "visible": kwargs.get("visible", True),
         "showlegend": kwargs["showlegend"]
     }

--- a/trendyqc/trend_monitoring/backend_utils/plot.py
+++ b/trendyqc/trend_monitoring/backend_utils/plot.py
@@ -426,13 +426,16 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
     else:
         plot_data = {"plot": json.dumps(combined_traces)}
 
-    return {
-        **plot_data,
-        **{
-            "first_lane": json.dumps(first_lane_traces),
-            "second_lane": json.dumps(second_lane_traces)
-        }
-    }
+    return [
+        {
+            **plot_data,
+            **{
+                "first_lane": json.dumps(first_lane_traces),
+                "second_lane": json.dumps(second_lane_traces)
+            }
+        },
+        json.dumps(True if len(metrics) > 1 else False)
+    ]
 
 
 def create_trace(data, data_column, **kwargs):

--- a/trendyqc/trend_monitoring/backend_utils/plot.py
+++ b/trendyqc/trend_monitoring/backend_utils/plot.py
@@ -2,6 +2,7 @@ import json
 from statistics import median
 from typing import Dict
 
+import numpy as np
 import pandas as pd
 
 from django.apps import apps
@@ -40,11 +41,11 @@ def prepare_filter_data(filter_recap: Dict) -> Dict:
     data.setdefault("y_axis", [])
 
     for field, value in filter_recap.items():
-        # I'm setting a list by default because I want the user to be able to
-        # select multiple runs for example
         if field in [
             "assay_select", "run_select", "sequencer_select"
         ]:
+            # I'm setting a list by default because I want the user to be able
+            # to select multiple runs for example
             data["subset"].setdefault(field, [])
 
             if isinstance(value, list):
@@ -157,42 +158,41 @@ def get_data_for_plotting(
 
         # get the filter string needed to get the metric data from the queryset
         metric_filter = get_metric_filter(model, form_metric)
-        metric_field = metric_filter.split("__")[-1]
 
         df = pd.DataFrame(
             report_sample_queryset.values(
                 "sample__sample_id", "report__date",
-                "report__project_name", metric_filter
+                "report__project_name", *metric_filter
             )
         )
 
-        df.columns = ["sample_id", "date", "project_name", metric_field]
+        df.columns = ["sample_id", "date", "project_name", *metric_filter]
 
         for project_name in df["project_name"].unique():
             # get subdataframe for a single run
             data_one_run = df[df["project_name"] == project_name]
 
-            # get the metric series
-            metric_series = data_one_run[metric_field]
+            # get the metric df
+            metric_df = data_one_run[metric_filter]
 
-            # if all values are None/NaN
-            if metric_series.isnull().all():
-                projects_no_metrics.setdefault(metric, []).append(project_name)
+            for series_name, series in metric_df.items():
+                # if all values are None/NaN
+                if series.isnull().all():
+                    projects_no_metrics.setdefault(metric, set()).add(project_name)
 
-            # if one value is None/NaN
-            elif metric_series.isnull().any():
-                samples_no_metric.setdefault(metric, {})
+                # if one value is None/NaN
+                elif series.isnull().any():
+                    samples_no_metric.setdefault(metric, {})
 
-                for values in data_one_run.loc[metric_series.isna()].values:
-                    samples_no_metric[metric].setdefault(project_name, [])
-                    # extract sample name
-                    data = [value for value in values][0]
-                    samples_no_metric[metric][project_name].append(data)
+                    for values in data_one_run.loc[series.isna()].values:
+                        samples_no_metric[metric].setdefault(project_name, set())
+                        # extract sample name
+                        data = [value for value in values][0]
+                        samples_no_metric[metric][project_name].add(data)
 
-        # filter out the None/NaN values in the metric column
-        pd_data_no_none = df[~df[metric_field].isna()]
+        # filter out the None/NaN values in the metric column(s)
+        pd_data_no_none = df[df[metric_filter].notna().any(axis=1)]
 
-        # convert dict into a dataframe
         list_df.append(pd_data_no_none)
 
     return list_df, projects_no_metrics, samples_no_metric
@@ -226,13 +226,45 @@ def get_metric_filter(form_model: str, form_metric: str) -> str:
 
     original_metric_filter = list(metric_filter_dict.values())[0]
 
+    # for fastqc and picard base distribution, build the metric filter directly
+    # to take into account the lanes
+    if "read_data" in original_metric_filter:
+        metric_filter = [
+            f"fastqc__{lane_read}__{original_metric_filter.split('__')[-1]}"
+            for lane_read in [
+                "read_data_1st_lane_R1", "read_data_1st_lane_R2",
+                "read_data_2nd_lane_R1", "read_data_2nd_lane_R2"
+            ]
+        ]
+        metric_filter.insert(0, "fastqc__read_data_2nd_lane_R1__lane")
+        metric_filter.insert(0, "fastqc__read_data_1st_lane_R1__lane")
+        return metric_filter
+
+    elif "base_distribution" in original_metric_filter:
+        metric_filter = [
+            f"picard__{lane_read}__{original_metric_filter.split('__')[-1]}"
+            for lane_read in [
+                "base_distribution_by_cycle_metrics_1st_lane_R1",
+                "base_distribution_by_cycle_metrics_1st_lane_R2",
+                "base_distribution_by_cycle_metrics_2nd_lane_R1",
+                "base_distribution_by_cycle_metrics_2nd_lane_R2"
+            ]
+        ]
+        metric_filter.insert(
+            0, "picard__base_distribution_by_cycle_metrics_2nd_lane_R1__lane"
+        )
+        metric_filter.insert(
+            0, "picard__base_distribution_by_cycle_metrics_1st_lane_R1__lane"
+        )
+        return metric_filter
+
     # handle cases where there is an intermediary table between Report sample
     # and the table containing the metric field:
     # The list represent the cases we want to test. "" is testing if the field
     # is in a table directly linked to report_sample. Fastqc, picard and happy
     # are the intermediate tables that could separate the field to
     # report_sample
-    for intermediate_table in ["", "fastqc", "picard", "happy"]:
+    for intermediate_table in ["", "picard", "happy"]:
         if intermediate_table != "":
             # add the intermediary table in the filter string
             metric_filter = f"{intermediate_table}__{original_metric_filter}"
@@ -246,7 +278,7 @@ def get_metric_filter(form_model: str, form_metric: str) -> str:
         except FieldError:
             continue
         else:
-            return metric_filter
+            return [metric_filter]
 
     return None
 
@@ -258,6 +290,7 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
         plot_data (pd.DataFrame): Pandas Dataframe containing the data to plot
 
     Example format:
+    For tools with no lane data, the dataframe should only be 4 columns:
         +-----------+-------+--------------+--------------+
         | sample_id | date  | project_name | metric_field |
         +-----------+-------+--------------+--------------+
@@ -267,9 +300,18 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
         | sample4   | date2 | name3        | value4       |
         +-----------+-------+--------------+--------------+
 
+    For tools with lane data, the dataframe should be 8 columns:
+        +-----------+-------+--------------+------------+-------------+--------------------+--------------------+--------------------+--------------------+
+        | sample_id | date  | project_name | first lane | second lane | metric_field_L1_R1 | metric_field_L1_R2 | metric_field_L2_R1 | metric_field_L2_R2 |
+        +-----------+-------+--------------+------------+-------------+--------------------+--------------------+--------------------+--------------------+
+        | sample1   | date1 | name1        | value1     | value1      | value1             | value1             | value1             | value1             |
+        | sample2   | date1 | name1        | value2     | value2      | value2             | value2             | value2             | value2             |
+        | sample3   | date1 | name2        | value3     | value3      | value3             | value3             | value3             | value3             |
+        | sample4   | date2 | name3        | value4     | value4      | value4             | value4             | value4             | value4             |
+        +-----------+-------+--------------+------------+-------------+--------------------+--------------------+--------------------+--------------------+
+
     Returns:
-        str: Serialized string of the boxplot data that needs to be plotted
-        str: Serialized string of the trend data that needs to be plotted
+        list: List of lists of the traces that need to be plotted
     """
 
     date_coloring = {
@@ -287,53 +329,169 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
         12: "00a600",
     }
 
-    # create the list of boxplots that will be displayed in the plot
-    traces = []
+    # Bool to indicate whether legend needs to be displayed
+    shown_legend = True
 
-    # formatting median trace
-    median_trace = {
-        "mode": "lines",
-        "name": "trend",
-        "line": {
-            "dash": "dashdot",
-            "width": 2
-        }
-    }
-    median_trace.setdefault("x", [])
-    median_trace.setdefault("y", [])
+    # get the column names for the metrics: either 6 columns when there is data
+    # for lanes or 1 column if the data is not separated by lane
+    metrics = plot_data.columns[3:]
 
-    metric_name = plot_data.columns[-1]
+    combined_traces = []
+    first_lane_traces = []
+    second_lane_traces = []
+    default_traces = []
 
+    # for each project name, gather the necessary data to create the individual
+    # boxplots
     for project_name in plot_data.sort_values("date")["project_name"].unique():
+        # get sub df with for the project name
         data_one_run = plot_data[plot_data["project_name"] == project_name]
-
         report_date = data_one_run["date"].unique()[0]
         boxplot_color = date_coloring[report_date.month]
 
-        sub_df = data_one_run.sort_values(
-            metric_name
-        )[["sample_id", metric_name]]
+        if len(metrics) > 1:
+            first_lane_column = data_one_run.columns[3]
+            second_lane_column = data_one_run.columns[4]
 
-        # convert values to native python types for JSON serialisation
-        data_values = [value.item() for value in sub_df[metric_name].values]
+            first_lane = list(set(data_one_run[first_lane_column].values))[0]
+            second_lane = list(set(data_one_run[second_lane_column].values))[0]
 
-        # setup each boxplot with the appropriate annotation and data points
-        trace = {
-            "x0": project_name,
-            "y": data_values,
-            "name": str(report_date),
-            "type": "box",
-            "text": list(sub_df["sample_id"].values),
-            "boxpoints": "suspectedoutliers",
-            "marker": {
-                "color": boxplot_color,
-            }
+            data_one_run["Default data"] = data_one_run.apply(
+                calculate_mean_across_columns, axis=1, args=(range(5, 9))
+            )
+            data_one_run[first_lane] = data_one_run.apply(
+                calculate_mean_across_columns, axis=1, args=([5, 6])
+            )
+            data_one_run[second_lane] = data_one_run.apply(
+                calculate_mean_across_columns, axis=1, args=([7, 8])
+            )
+
+            default_data_trace = create_trace(
+                data_one_run, "Default data",
+                project_name=project_name,
+                name="Combined",
+                boxplot_color=boxplot_color,
+                showlegend=shown_legend
+            )
+
+            if first_lane:
+                first_lane_trace = create_trace(
+                    data_one_run, first_lane,
+                    project_name=project_name,
+                    name="First lane",
+                    visible="legendonly",
+                    hovertext=first_lane,
+                    lane=first_lane,
+                    boxplot_color=boxplot_color,
+                    showlegend=shown_legend
+                )
+                first_lane_traces.append(first_lane_trace)
+
+            if second_lane:
+                second_data_trace = create_trace(
+                    data_one_run, second_lane,
+                    project_name=project_name,
+                    name="Second lane",
+                    visible="legendonly",
+                    lane=second_lane,
+                    hovertext=second_lane,
+                    boxplot_color=boxplot_color,
+                    showlegend=shown_legend
+                )
+                second_lane_traces.append(second_data_trace)
+
+            shown_legend = False
+            combined_traces.append(default_data_trace)
+
+        else:
+            metric_name = data_one_run.columns[-1]
+
+            default_data_trace = create_trace(
+                data_one_run, metric_name,
+                project_name=project_name,
+                name=str(report_date),
+                boxplot_color=boxplot_color,
+                showlegend=False
+            )
+
+            default_traces.append(default_data_trace)
+
+    if default_traces:
+        plot_data = {"plot": json.dumps(default_traces)}
+    else:
+        plot_data = {"plot": json.dumps(combined_traces)}
+
+    return {
+        **plot_data,
+        **{
+            "first_lane": json.dumps(first_lane_traces),
+            "second_lane": json.dumps(second_lane_traces)
         }
-        traces.append(trace)
+    }
 
-        # add median of current boxplot for trend line
-        data_median = median(data_values)
-        median_trace["x"].append(project_name)
-        median_trace["y"].append(data_median)
 
-    return json.dumps(traces), json.dumps(median_trace)
+def create_trace(data, data_column, **kwargs):
+    """ Setup the trace according to given data
+
+    Args:
+        data (pd.DataFrame): Dataframe containing the data for that boxplot
+        data_column (str): Column name in which values are stored
+
+    Returns:
+        dict: Dict containing the data needed for Plotly
+    """
+
+    sub_df = data.sort_values(data_column)[["sample_id", data_column]]
+
+    # convert values to native python types for JSON serialisation
+    data_values = [
+        value.item() if isinstance(value, np.float64) else value
+        for value in sub_df[data_column].values
+    ]
+
+    if kwargs.get("lane", None):
+        legend_group = f"{kwargs['name']} | {kwargs.get('lane')}"
+    else:
+        legend_group = kwargs['name']
+
+    # setup each boxplot with the appropriate annotation and data points
+    trace = {
+        "x0": kwargs["project_name"],
+        "y": data_values,
+        "name": kwargs["name"],
+        "type": "box",
+        "text": list(sub_df["sample_id"].values),
+        "boxpoints": "suspectedoutliers",
+        "marker": {
+            "color": kwargs["boxplot_color"],
+        },
+        "legendgroup": legend_group,
+        "visible": kwargs.get("visible", True),
+        "showlegend": kwargs["showlegend"]
+    }
+
+    return trace
+
+
+def calculate_mean_across_columns(row, *columns):
+    """ Calculate the mean for a selection of columns
+
+    Args:
+        row (pd.Series): Series containing the data to manipulate
+
+    Returns:
+        float: Mean of the values for the select columns
+    """
+
+    denominator = 0
+    value = 0
+
+    for column in columns:
+        if row.iloc[column]:
+            value += row[column]
+            denominator += 1
+
+    if denominator:
+        return value / denominator
+    else:
+        return None

--- a/trendyqc/trend_monitoring/backend_utils/plot.py
+++ b/trendyqc/trend_monitoring/backend_utils/plot.py
@@ -384,15 +384,15 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
 
     group_colors = {}
 
+    # too many groups are possible
+    if len(colors) < len(groups):
+        return f"Not enough colors are possible for the groups: {groups}"
+
     # assign colors to groups
     for i, group in enumerate(groups):
         random_color = random.choice(colors)
         group_colors[group] = random_color
         colors.remove(random_color)
-
-        # too many groups are available
-        if not colors and i != len(groups) - 1:
-            raise AssertionError("No more colors possible")
 
     # first second lane flag to fix duplication in the legend
     seen_first_lane = False
@@ -437,7 +437,7 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
 
             for name, sub_dict in args.items():
                 # calculate mean across appropriate columns
-                data_one_run[name] = data_one_run[sub_dict["columns"]].mean(axis=1)
+                data_one_run[name] = data_one_run.loc[sub_dict["columns"]].mean(axis=1)
 
                 if name == "First lane" and seen_first_lane:
                     shown_legend = False

--- a/trendyqc/trend_monitoring/backend_utils/plot.py
+++ b/trendyqc/trend_monitoring/backend_utils/plot.py
@@ -360,15 +360,15 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
             second_lane = list(set(data_one_run[second_lane_column].values))[0]
 
             # calculate the mean across all lanes and individual lanes
-            data_one_run["Default data"] = data_one_run.apply(
-                calculate_mean_across_columns, axis=1, args=(range(5, 9))
-            )
-            data_one_run[first_lane] = data_one_run.apply(
-                calculate_mean_across_columns, axis=1, args=([5, 6])
-            )
-            data_one_run[second_lane] = data_one_run.apply(
-                calculate_mean_across_columns, axis=1, args=([7, 8])
-            )
+            data_one_run["Default data"] = data_one_run[
+                plot_data.columns[5:]
+            ].mean(axis=1)
+            data_one_run[first_lane] = data_one_run[
+                plot_data.columns[5:7]
+            ].mean(axis=1)
+            data_one_run[second_lane] = data_one_run[
+                plot_data.columns[7:9]
+            ].mean(axis=1)
 
             # create box for combined data
             default_data_trace = create_trace(
@@ -542,27 +542,3 @@ def get_date_from_project_name(project_name):
     month_abbr = calendar.month_abbr[int(matches[0][2:4])]
 
     return f"{month_abbr}. 20{matches[0][0:2]}"
-
-
-def calculate_mean_across_columns(row, *columns):
-    """ Calculate the mean for a selection of columns
-
-    Args:
-        row (pd.Series): Series containing the data to manipulate
-
-    Returns:
-        float: Mean of the values for the select columns
-    """
-
-    denominator = 0
-    value = 0
-
-    for column in columns:
-        if row.iloc[column]:
-            value += row[column]
-            denominator += 1
-
-    if denominator:
-        return value / denominator
-    else:
-        return None

--- a/trendyqc/trend_monitoring/models/bam_qc.py
+++ b/trendyqc/trend_monitoring/models/bam_qc.py
@@ -97,14 +97,14 @@ class Picard(models.Model):
         related_name="base_distribution_by_cycle_metrics_1st_lane_R2",
         on_delete=models.DO_NOTHING, blank=True, null=True
     )
-    base_distribution_by_cycle_metrics_2st_lane_R1 = models.ForeignKey(
+    base_distribution_by_cycle_metrics_2nd_lane_R1 = models.ForeignKey(
         "Base_distribution_by_cycle_metrics",
-        related_name="base_distribution_by_cycle_metrics_2st_lane_R1",
+        related_name="base_distribution_by_cycle_metrics_2nd_lane_R1",
         on_delete=models.DO_NOTHING, blank=True, null=True
     )
-    base_distribution_by_cycle_metrics_2st_lane_R2 = models.ForeignKey(
+    base_distribution_by_cycle_metrics_2nd_lane_R2 = models.ForeignKey(
         "Base_distribution_by_cycle_metrics",
-        related_name="base_distribution_by_cycle_metrics_2st_lane_R2",
+        related_name="base_distribution_by_cycle_metrics_2nd_lane_R2",
         on_delete=models.DO_NOTHING, blank=True, null=True
     )
     gc_bias_metrics = models.ForeignKey(

--- a/trendyqc/trend_monitoring/templates/plot.html
+++ b/trendyqc/trend_monitoring/templates/plot.html
@@ -123,9 +123,9 @@ var layout = {
         title: "{{y_axis|escapejs}}",
         showline: true,
         gridwidth: 3,
-        ticklen: 10
+        ticklen: 10,
+        categoryorder: "array"
     },
-    legend: {traceorder: "normal"},
     height: 1000,
     showlegend: true,
     boxgap: 0.1,

--- a/trendyqc/trend_monitoring/templates/plot.html
+++ b/trendyqc/trend_monitoring/templates/plot.html
@@ -100,11 +100,6 @@
 
 <script>
 var plot_data = JSON.parse("{{plot|escapejs}}");
-if ({{ is_grouped }}) {
-    var boxmode = "group";
-} else {
-    var boxmode = "overlay";
-}
 var layout = {
     xaxis: {
         automargin: true,
@@ -129,11 +124,9 @@ var layout = {
     showlegend: true,
     boxgap: 0.1,
     boxgroupgap: 0.075,
-    boxmode: boxmode
+    boxmode: "group"
 };
 Plotly.newPlot("plot-div", plot_data, layout, {responsive: true});
-Plotly.addTraces("plot-div", JSON.parse("{{first_lane|escapejs}}"));
-Plotly.addTraces("plot-div", JSON.parse("{{second_lane|escapejs}}"));
 
 function saveFilter() {
     var filter_name = prompt("Name your filter:", "");

--- a/trendyqc/trend_monitoring/templates/plot.html
+++ b/trendyqc/trend_monitoring/templates/plot.html
@@ -100,6 +100,11 @@
 
 <script>
 var plot_data = JSON.parse("{{plot|escapejs}}");
+if ({{ is_grouped }}) {
+    var boxmode = "group";
+} else {
+    var boxmode = "overlay";
+}
 var layout = {
     xaxis: {
         automargin: true,
@@ -120,11 +125,12 @@ var layout = {
         gridwidth: 3,
         ticklen: 10
     },
+    legend: {traceorder: "normal"},
     height: 1000,
     showlegend: true,
     boxgap: 0.1,
     boxgroupgap: 0.075,
-    boxmode: "group"
+    boxmode: boxmode
 };
 Plotly.newPlot("plot-div", plot_data, layout, {responsive: true});
 

--- a/trendyqc/trend_monitoring/templates/plot.html
+++ b/trendyqc/trend_monitoring/templates/plot.html
@@ -102,19 +102,29 @@
 var plot_data = JSON.parse("{{plot|escapejs}}");
 var layout = {
     xaxis: {
-        type: "category",
         automargin: true,
         title: {
             text: "Projects (ordered by date)",
             standoff: 10
-        }
+        },
+        showline: true,
+        tickson: "boundaries",
+        ticklen: 15,
+        showdividers: true,
+        dividercolor: 'grey',
+        dividerwidth: 2,
     },
     yaxis: {
-        title: "{{y_axis|escapejs}}"
+        title: "{{y_axis|escapejs}}",
+        showline: true,
+        mirror: "ticks",
+        gridwidth: 3,
     },
     height: 1000,
     showlegend: true,
-    boxgap: 0.1
+    boxgap: 0.1,
+    boxgroupgap: 0.075,
+    boxmode: "group"
 };
 Plotly.newPlot("plot-div", plot_data, layout, {responsive: true});
 Plotly.addTraces("plot-div", JSON.parse("{{first_lane|escapejs}}"));

--- a/trendyqc/trend_monitoring/templates/plot.html
+++ b/trendyqc/trend_monitoring/templates/plot.html
@@ -100,6 +100,11 @@
 
 <script>
 var plot_data = JSON.parse("{{plot|escapejs}}");
+if ({{ is_grouped }}) {
+    var boxmode = "group";
+} else {
+    var boxmode = "overlay";
+}
 var layout = {
     xaxis: {
         automargin: true,
@@ -117,14 +122,14 @@ var layout = {
     yaxis: {
         title: "{{y_axis|escapejs}}",
         showline: true,
-        mirror: "ticks",
         gridwidth: 3,
+        ticklen: 10
     },
     height: 1000,
     showlegend: true,
     boxgap: 0.1,
     boxgroupgap: 0.075,
-    boxmode: "group"
+    boxmode: boxmode
 };
 Plotly.newPlot("plot-div", plot_data, layout, {responsive: true});
 Plotly.addTraces("plot-div", JSON.parse("{{first_lane|escapejs}}"));

--- a/trendyqc/trend_monitoring/templates/plot.html
+++ b/trendyqc/trend_monitoring/templates/plot.html
@@ -100,8 +100,6 @@
 
 <script>
 var plot_data = JSON.parse("{{plot|escapejs}}");
-var trend_data = JSON.parse("{{trend|escapejs}}");
-plot_data.push(trend_data);
 var layout = {
     xaxis: {
         type: "category",
@@ -115,10 +113,12 @@ var layout = {
         title: "{{y_axis|escapejs}}"
     },
     height: 1000,
-    showlegend: false,
+    showlegend: true,
     boxgap: 0.1
 };
 Plotly.newPlot("plot-div", plot_data, layout, {responsive: true});
+Plotly.addTraces("plot-div", JSON.parse("{{first_lane|escapejs}}"));
+Plotly.addTraces("plot-div", JSON.parse("{{second_lane|escapejs}}"));
 
 function saveFilter() {
     var filter_name = prompt("Name your filter:", "");

--- a/trendyqc/trend_monitoring/templates/plot.html
+++ b/trendyqc/trend_monitoring/templates/plot.html
@@ -4,142 +4,145 @@
 
 {% block plot %}
 
-<div class="recap" style="width:90%; margin: auto; padding: 10px; ">
-    <!-- 1st inner div: recap of plotting filter -->
-    {% if form %}
-        <div class="recap-column" style="display: inline-block; *display: inline; zoom: 1; vertical-align: top; width:40%; padding: 10px;">
-            <div class="recap">
-                <h5>Plotting filter</h5>
-                {% for key, values in form.items %}
-                    <ul>
-                        - <b>{{ key }}</b>:
-                        {% for value in values %}
-                            <ul>- {{ value }}</ul>
-                        {% endfor %}
-                    </ul>
-                {% endfor %}
-            </div>
-        </div>
-
-        <div class="button-column" style="display: inline-block; *display: inline; zoom: 1; vertical-align: top; width:30%; padding: 10px;">
-            <form action="{% url "Plot" %}" method="post" id="return_dashboard"> {% csrf_token %}
-                    <input class="btn btn-info" type="submit" name="dashboard" value="Go back to dashboard">
-            </form>
-
-            <br>
-
-            {% if user.is_authenticated %}
-                <form action="{% url "Plot" %}" method="post" id="filter_form"> {% csrf_token %}
-                    <button class="btn btn-info" type="submit" value="Save filter" name="save_filter" id="save_filter" onclick="saveFilter();"/>Save filter</button>
-                </form>
-            {% endif %}
-        </div>
-    {% endif %}
-</div>
-
-<br>
-
-<div class="skipped_div" style="width:90%; margin: auto; padding: 10px; ">
-    <!-- 2nd potential inner div: collapsible button for displaying projects which didn't have that metric in the database -->
-    {% if skipped_projects %}
-        <div class="skipped-column" style="display: inline-block; *display: inline; zoom: 1; vertical-align: top; width:45%; padding: 10px;">
-            <p>
-                <button class="btn btn-warning" type="button" data-toggle="collapse" data-target="#collapseSkipped" aria-expanded="false" aria-controls="collapseSkipped">
-                    Skipped projects (no metrics found)
-                </button>
-            </p>
-            <div class="collapse" id="collapseSkipped">
-                <div class="card card-body">
-                    <ul>
-                    {% for metric, projects in skipped_projects.items %}
-                        <li>{{ metric }}</li>
+{% if plot %}
+    <div class="recap" style="width:90%; margin: auto; padding: 10px; ">
+        <!-- 1st inner div: recap of plotting filter -->
+        {% if form %}
+            <div class="recap-column" style="display: inline-block; *display: inline; zoom: 1; vertical-align: top; width:40%; padding: 10px;">
+                <div class="recap">
+                    <h5>Plotting filter</h5>
+                    {% for key, values in form.items %}
                         <ul>
-                        {% for project in projects %}
-                            <li>{{ project }}</li>
-                        {% endfor %}
+                            - <b>{{ key }}</b>:
+                            {% for value in values %}
+                                <ul>- {{ value }}</ul>
+                            {% endfor %}
                         </ul>
                     {% endfor %}
-                    </ul>
                 </div>
             </div>
-        </div>
-    {% endif %}
-    <!-- 3rd potential inner div: collapsible button for displaying samples which didn't have that metric -->
-    <!-- Example: X226025-GM2312272-23NGCEN4-9527-F-99347387-FR in 002_230706_A01295_0198_AHHHT5DRX3_CEN for gt_depth_sd in Somalier -->
-    {% if skipped_samples %}
-        <div class="skipped-column" style="display: inline-block; *display: inline; zoom: 1; vertical-align: top; width:45%; padding: 10px;">
-            <p>
-                <button class="btn btn-warning" type="button" data-toggle="collapse" data-target="#collapseSkipped" aria-expanded="false" aria-controls="collapseSkipped">
-                    Skipped samples (no metrics found)
-                </button>
-            </p>
-            <div class="collapse" id="collapseSkipped">
-                <div class="card card-body">
-                    <ul>
-                    {% for metric, projects in skipped_samples.items %}
-                        <li>{{ metric }}</li>
+
+            <div class="button-column" style="display: inline-block; *display: inline; zoom: 1; vertical-align: top; width:30%; padding: 10px;">
+                <form action="{% url "Plot" %}" method="post" id="return_dashboard"> {% csrf_token %}
+                        <input class="btn btn-info" type="submit" name="dashboard" value="Go back to dashboard">
+                </form>
+
+                <br>
+
+                {% if user.is_authenticated %}
+                    <form action="{% url "Plot" %}" method="post" id="filter_form"> {% csrf_token %}
+                        <button class="btn btn-info" type="submit" value="Save filter" name="save_filter" id="save_filter" onclick="saveFilter();"/>Save filter</button>
+                    </form>
+                {% endif %}
+            </div>
+        {% endif %}
+    </div>
+
+    <br>
+
+    <div class="skipped_div" style="width:90%; margin: auto; padding: 10px; ">
+        <!-- 2nd potential inner div: collapsible button for displaying projects which didn't have that metric in the database -->
+        {% if skipped_projects %}
+            <div class="skipped-column" style="display: inline-block; *display: inline; zoom: 1; vertical-align: top; width:45%; padding: 10px;">
+                <p>
+                    <button class="btn btn-warning" type="button" data-toggle="collapse" data-target="#collapseSkipped" aria-expanded="false" aria-controls="collapseSkipped">
+                        Skipped projects (no metrics found)
+                    </button>
+                </p>
+                <div class="collapse" id="collapseSkipped">
+                    <div class="card card-body">
                         <ul>
-                        {% for project, samples in projects.items %}
-                            <li>{{ project }}</li>
+                        {% for metric, projects in skipped_projects.items %}
+                            <li>{{ metric }}</li>
                             <ul>
-                            {% for sample in samples %}
-                                <li>{{ sample }}</li>
+                            {% for project in projects %}
+                                <li>{{ project }}</li>
                             {% endfor %}
                             </ul>
                         {% endfor %}
                         </ul>
-                    {% endfor %}
-                    </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    {% endif %}
-</div>
+        {% endif %}
+        <!-- 3rd potential inner div: collapsible button for displaying samples which didn't have that metric -->
+        <!-- Example: X226025-GM2312272-23NGCEN4-9527-F-99347387-FR in 002_230706_A01295_0198_AHHHT5DRX3_CEN for gt_depth_sd in Somalier -->
+        {% if skipped_samples %}
+            <div class="skipped-column" style="display: inline-block; *display: inline; zoom: 1; vertical-align: top; width:45%; padding: 10px;">
+                <p>
+                    <button class="btn btn-warning" type="button" data-toggle="collapse" data-target="#collapseSkipped" aria-expanded="false" aria-controls="collapseSkipped">
+                        Skipped samples (no metrics found)
+                    </button>
+                </p>
+                <div class="collapse" id="collapseSkipped">
+                    <div class="card card-body">
+                        <ul>
+                        {% for metric, projects in skipped_samples.items %}
+                            <li>{{ metric }}</li>
+                            <ul>
+                            {% for project, samples in projects.items %}
+                                <li>{{ project }}</li>
+                                <ul>
+                                {% for sample in samples %}
+                                    <li>{{ sample }}</li>
+                                {% endfor %}
+                                </ul>
+                            {% endfor %}
+                            </ul>
+                        {% endfor %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+    </div>
 
-<div id="plot-div"></div>
+    <div id="plot-div"></div>
 
-<script>
-var plot_data = JSON.parse("{{plot|escapejs}}");
-if ({{ is_grouped }}) {
-    var boxmode = "group";
-} else {
-    var boxmode = "overlay";
-}
-var layout = {
-    xaxis: {
-        automargin: true,
-        title: {
-            text: "Projects (ordered by date)",
-            standoff: 10
+    <script>
+    var plot_data = JSON.parse("{{plot|escapejs}}");
+    if ({{ is_grouped }}) {
+        var boxmode = "group";
+    } else {
+        var boxmode = "overlay";
+    }
+    var layout = {
+        xaxis: {
+            automargin: true,
+            title: {
+                text: "Projects (ordered by date)",
+                standoff: 10
+            },
+            showline: true,
+            tickson: "boundaries",
+            ticklen: 15,
+            showdividers: true,
+            dividercolor: 'grey',
+            dividerwidth: 2,
         },
-        showline: true,
-        tickson: "boundaries",
-        ticklen: 15,
-        showdividers: true,
-        dividercolor: 'grey',
-        dividerwidth: 2,
-    },
-    yaxis: {
-        title: "{{y_axis|escapejs}}",
-        showline: true,
-        gridwidth: 3,
-        ticklen: 10,
-        categoryorder: "array"
-    },
-    height: 1000,
-    showlegend: true,
-    boxgap: 0.1,
-    boxgroupgap: 0.075,
-    boxmode: boxmode
-};
-Plotly.newPlot("plot-div", plot_data, layout, {responsive: true});
+        yaxis: {
+            title: "{{y_axis|escapejs}}",
+            showline: true,
+            gridwidth: 3,
+            ticklen: 10,
+            categoryorder: "array"
+        },
+        height: 1000,
+        showlegend: true,
+        boxgap: 0.1,
+        boxgroupgap: 0.075,
+        boxmode: boxmode
+    };
+    Plotly.newPlot("plot-div", plot_data, layout, {responsive: true});
 
-function saveFilter() {
-    var filter_name = prompt("Name your filter:", "");
-    if (!filter_name) return;
-    $("#save_filter").val(filter_name);
-    $("#filter_form").submit();
-}
-</script>
+    function saveFilter() {
+        var filter_name = prompt("Name your filter:", "");
+        if (!filter_name) return;
+        $("#save_filter").val(filter_name);
+        $("#filter_form").submit();
+    }
+    </script>
+
+{% endif %}
 
 {% endblock %}

--- a/trendyqc/trend_monitoring/views.py
+++ b/trendyqc/trend_monitoring/views.py
@@ -295,7 +295,18 @@ class Plot(View):
                 for k, v in form.items()
             }
 
-            json_plot_data, is_grouped = format_data_for_plotly_js(data_dfs[0])
+            data = format_data_for_plotly_js(data_dfs[0])
+
+            if len(data) == 2:
+                json_plot_data, is_grouped = data
+            else:
+                msg = (
+                    "An issue has occurred. Please contact the bioinformatics "
+                    "team."
+                )
+                messages.add_message(request, messages.ERROR, msg)
+                logger.error(data)
+                return render(request, self.template_name)
 
             context = {
                 "form": dict(sorted(formatted_form_data.items())),

--- a/trendyqc/trend_monitoring/views.py
+++ b/trendyqc/trend_monitoring/views.py
@@ -292,15 +292,6 @@ class Plot(View):
 
             json_plot_data = format_data_for_plotly_js(data_dfs[0])
 
-            if len(json_plot_data) == 1:
-                data = {"plot": json.dumps(json_plot_data[0])}
-            else:
-                data = {
-                    "plot": json.dumps(json_plot_data[0]),
-                    "first_lane": json.dumps(json_plot_data[1]),
-                    "second_lane": json.dumps(json_plot_data[2])
-                }
-
             formatted_form_data = {
                 k: ([v] if not isinstance(v, list) else v)
                 for k, v in form.items()
@@ -313,7 +304,9 @@ class Plot(View):
                 "skipped_samples": samples_no_metric
             }
 
-            return render(request, self.template_name, {**context, **data})
+            return render(
+                request, self.template_name, {**context, **json_plot_data}
+            )
 
         return render(request, self.template_name)
 

--- a/trendyqc/trend_monitoring/views.py
+++ b/trendyqc/trend_monitoring/views.py
@@ -290,9 +290,16 @@ class Plot(View):
                     f"{filter_data}"
                 )
 
-            (
-                json_plot_data, json_trend_data
-            ) = format_data_for_plotly_js(data_dfs[0])
+            json_plot_data = format_data_for_plotly_js(data_dfs[0])
+
+            if len(json_plot_data) == 1:
+                data = {"plot": json.dumps(json_plot_data[0])}
+            else:
+                data = {
+                    "plot": json.dumps(json_plot_data[0]),
+                    "first_lane": json.dumps(json_plot_data[1]),
+                    "second_lane": json.dumps(json_plot_data[2])
+                }
 
             formatted_form_data = {
                 k: ([v] if not isinstance(v, list) else v)
@@ -301,13 +308,12 @@ class Plot(View):
 
             context = {
                 "form": dict(sorted(formatted_form_data.items())),
-                "plot": json_plot_data,
-                "trend": json_trend_data,
                 "y_axis": " | ".join(filter_data["y_axis"]),
                 "skipped_projects": projects_no_metric,
                 "skipped_samples": samples_no_metric
             }
-            return render(request, self.template_name, context)
+
+            return render(request, self.template_name, {**context, **data})
 
         return render(request, self.template_name)
 

--- a/trendyqc/trend_monitoring/views.py
+++ b/trendyqc/trend_monitoring/views.py
@@ -295,14 +295,15 @@ class Plot(View):
                 for k, v in form.items()
             }
 
+            json_plot_data, is_grouped = format_data_for_plotly_js(data_dfs[0])
+
             context = {
                 "form": dict(sorted(formatted_form_data.items())),
                 "y_axis": " | ".join(filter_data["y_axis"]),
                 "skipped_projects": projects_no_metric,
                 "skipped_samples": samples_no_metric,
+                "is_grouped": is_grouped
             }
-
-            json_plot_data = format_data_for_plotly_js(data_dfs[0])
 
             return render(
                 request, self.template_name, {**context, **{"plot": json_plot_data}}

--- a/trendyqc/trend_monitoring/views.py
+++ b/trendyqc/trend_monitoring/views.py
@@ -290,7 +290,7 @@ class Plot(View):
                     f"{filter_data}"
                 )
 
-            json_plot_data = format_data_for_plotly_js(data_dfs[0])
+            json_plot_data, is_grouped = format_data_for_plotly_js(data_dfs[0])
 
             formatted_form_data = {
                 k: ([v] if not isinstance(v, list) else v)
@@ -301,7 +301,8 @@ class Plot(View):
                 "form": dict(sorted(formatted_form_data.items())),
                 "y_axis": " | ".join(filter_data["y_axis"]),
                 "skipped_projects": projects_no_metric,
-                "skipped_samples": samples_no_metric
+                "skipped_samples": samples_no_metric,
+                "is_grouped": is_grouped
             }
 
             return render(

--- a/trendyqc/trend_monitoring/views.py
+++ b/trendyqc/trend_monitoring/views.py
@@ -290,8 +290,6 @@ class Plot(View):
                     f"{filter_data}"
                 )
 
-            json_plot_data, is_grouped = format_data_for_plotly_js(data_dfs[0])
-
             formatted_form_data = {
                 k: ([v] if not isinstance(v, list) else v)
                 for k, v in form.items()
@@ -302,11 +300,12 @@ class Plot(View):
                 "y_axis": " | ".join(filter_data["y_axis"]),
                 "skipped_projects": projects_no_metric,
                 "skipped_samples": samples_no_metric,
-                "is_grouped": is_grouped
             }
 
+            json_plot_data = format_data_for_plotly_js(data_dfs[0])
+
             return render(
-                request, self.template_name, {**context, **json_plot_data}
+                request, self.template_name, {**context, **{"plot": json_plot_data}}
             )
 
         return render(request, self.template_name)


### PR DESCRIPTION
Closes #92 
Closes #94 

### Backend
- `get_data_for_plotting`:
    - make the gathering of data dynamic i.e. if multiple lanes, check absence of data for each lane
- `get_metric_filter`:
    - build the filter as soon as `read_data` aka fastqc or `base_distribution` is detected for lane purposes
- `format_data_for_plotly_js`:
    - remove median trace
    - create boxes for the first and second lanes if needed
    - setup traces to be further divided by month
- *NEW* `create_trace`:
    - allows fine tuning of trace creation via kwargs
- *NEW* `get_date_from_project_name`:
    - given the project name extract the date to format it for the xaxis
- *NEW* `calculate_mean_across_columns`:
    - allows computation of mean across columns given a pandas series (used in conjunction of `apply`)
### Models
- fix error field names for `base_distribution`
### Template
- `plot`:
    - add dividers to xaxis to display month and year
    - show lines for x/y axes
    - boxmode thingy for no overlap when having multiple boxes for one tick

![image](https://github.com/eastgenomics/trendyQC/assets/25991776/1271bfc2-14f8-4273-bb1c-befa75bd7d53)

![image](https://github.com/eastgenomics/trendyQC/assets/25991776/e698f1d9-8dfd-470f-ac90-d23443c655cd)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/trendyQC/93)
<!-- Reviewable:end -->
