### PR TITLE
In 742 add default date range when not selecting date

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pandas==2.0.3
 plotly==5.15.0
 psycopg2==2.9.5
 psycopg2-binary==2.9.5
+python-dateutil==2.9.0
 python-dotenv==1.0.0
 python-ldap==3.4.3
 pytz==2022.7.1

--- a/trendyqc/trend_monitoring/forms.py
+++ b/trendyqc/trend_monitoring/forms.py
@@ -1,5 +1,6 @@
 import datetime
 
+from dateutil.relativedelta import relativedelta
 from django import forms
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.exceptions import ValidationError
@@ -65,32 +66,29 @@ class FilterForm(forms.Form):
             ).date()
             cleaned_data["date_end"] = end_date
 
-        if not start_date and end_date:
-            self.add_error(
-                "date_start", ValidationError("No start date selected")
-            )
+        if not start_date:
+            start_date = datetime.date.today() + relativedelta(months=-6)
+            cleaned_data["date_start"] = start_date
 
         # if start date provided but not end date, define end date as today's
         # date
-        if not end_date and start_date:
-            now = datetime.date.today()
-            cleaned_data["date_end"] = now
-            end_date = now
+        if not end_date:
+            end_date = datetime.date.today()
+            cleaned_data["date_end"] = end_date
 
         if not any(run_subset):
             self.add_error(None, ValidationError("No subset of runs selected"))
 
         # basic check if the start date is later than the end date
-        if end_date and start_date:
-            if end_date < start_date:
-                self.add_error(
-                    None, ValidationError(
-                        (
-                            "Date end cannot be smaller than date start: "
-                            f"{start_date} - {end_date}"
-                        )
+        if end_date < start_date:
+            self.add_error(
+                None, ValidationError(
+                    (
+                        "Date end cannot be smaller than date start: "
+                        f"{start_date} - {end_date}"
                     )
                 )
+            )
 
         if not cleaned_data.get("metrics_y", None):
             self.add_error(None, ValidationError("No Y-axis metric selected"))
@@ -115,11 +113,13 @@ class LoginForm(forms.Form):
     username = forms.CharField(
         label='Username',
         widget=forms.TextInput(
-        attrs={'class': 'form-input', 'placeholder': 'Enter username'})
+            attrs={'class': 'form-input', 'placeholder': 'Enter username'}
+        )
     )
 
     password = forms.CharField(
         label='Password',
         widget=forms.PasswordInput(
-        attrs={'class': 'form-input', 'placeholder': 'Enter password'})
+            attrs={'class': 'form-input', 'placeholder': 'Enter password'}
+        )
     )

--- a/trendyqc/trend_monitoring/templates/dashboard.html
+++ b/trendyqc/trend_monitoring/templates/dashboard.html
@@ -56,6 +56,7 @@
                 </ul>
                 <ul>
                     <input type="date" name="date_start"> - <input type="date" name="date_end">
+                    <img src="{% static "images/exclamation-triangle.svg" %}" data-bs-toggle="tooltip" alt="Caution" width="25" height="25" title="If not selected, the default date range will get data for the last 6 months"/>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
- If no date range is selected, the data will be filtered to get data for the last 6 months only: Resolves #118 
- Tooltip image next to the date range picker to indicate this behaviour

![image](https://github.com/user-attachments/assets/4b6e3855-5aa9-4437-8a30-339f00c51ff5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/trendyQC/122)
<!-- Reviewable:end -->
