### PR TITLE
In 759 fix broken unittests

### DIFF
--- a/trendyqc/trend_monitoring/backend_utils/plot.py
+++ b/trendyqc/trend_monitoring/backend_utils/plot.py
@@ -351,7 +351,7 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
 
     # get groups of assay and sequencer id
     groups = build_groups(plot_data)
-    seen_groups = []
+    seen_groups = {}
 
     # too many groups are possible
     if sum([len(v) for v in colors.values()]) < len(groups):
@@ -376,7 +376,7 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
         if legend_name not in seen_groups:
             assay_colors = colors[assay_name]
             color_assay_sequencer = assay_colors.pop(0)
-            seen_groups.append(legend_name)
+            seen_groups[legend_name] = color_assay_sequencer
             shown_legend = True
         else:
             shown_legend = False
@@ -393,8 +393,8 @@ def format_data_for_plotly_js(plot_data: pd.DataFrame) -> tuple:
             args["First lane"]["columns"] = plot_data.columns[7:9]
             args["Second lane"]["columns"] = plot_data.columns[9:11]
 
-            args["Combined"]["boxplot_color"] = color_assay_sequencer
-            args["Combined"]["boxplot_line_color"] = color_assay_sequencer
+            args["Combined"]["boxplot_color"] = seen_groups[legend_name]
+            args["Combined"]["boxplot_line_color"] = seen_groups[legend_name]
             args["Combined"]["name"] = legend_name
             args["Combined"]["offsetgroup"] = legend_name
             args["Combined"]["legendgroup"] = legend_name

--- a/trendyqc/trend_monitoring/tests/test_plotting.py
+++ b/trendyqc/trend_monitoring/tests/test_plotting.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import random
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
@@ -606,14 +605,12 @@ class TestFormatDataForPlotlyJS(TestCase):
                 "sample_id": ["Sample1", "Sample2", "Sample3", "Sample4"],
                 "date": ["2024-06-24", "2024-06-24", "2024-06-24", "2024-06-24"],
                 "project_name": ["240624_Project1", "240624_Project1", "240624_Project2", "240624_Project2"],
-                "assay": ["Assay1", "Assay1", "Assay2", "Assay2"],
+                "assay": ["Cancer Endocrine Neurology", "Cancer Endocrine Neurology", "TruSight Oncology 500", "TruSight Oncology 500"],
                 "sequencer_id": ["Sequencer1", "Sequencer1", "Sequencer2", "Sequencer2"],
                 "verifybamid_data__freemix": [1, 2, 3, 4]
             }
         )
 
-        # set the seed to get expected results
-        random.seed(0)
         test_output = format_data_for_plotly_js(test_input)
         expected_output = (
             json.dumps([
@@ -623,20 +620,20 @@ class TestFormatDataForPlotlyJS(TestCase):
                         ["240624_Project1", "240624_Project1"]
                     ],
                     "y": [1.0, 2.0],
-                    "name": "Assay1 - Sequencer1",
+                    "name": "Cancer Endocrine Neurology - Sequencer1",
                     "type": "box",
                     "text": ["Sample1", "Sample2"],
                     "boxpoints": "suspectedoutliers",
                     "marker": {
-                        "color": "#6600cc",
+                        "color": "#FF0000",
                     },
                     "line": {
-                        "color": "#6600cc"
+                        "color": "#FF0000"
                     },
-                    "fillcolor": "#6600cc80",
+                    "fillcolor": "#FF000080",
                     "offsetgroup": "",
-                    "legendgroup": "Assay1 - Sequencer1",
-                    "legend": "Assay1 - Sequencer1",
+                    "legendgroup": "Cancer Endocrine Neurology - Sequencer1",
+                    "legend": "Cancer Endocrine Neurology - Sequencer1",
                     "visible": True,
                     "showlegend": True
                 },
@@ -646,20 +643,20 @@ class TestFormatDataForPlotlyJS(TestCase):
                         ["240624_Project2", "240624_Project2"]
                     ],
                     "y": [3.0, 4.0],
-                    "name": "Assay2 - Sequencer2",
+                    "name": "TruSight Oncology 500 - Sequencer2",
                     "type": "box",
                     "text": ["Sample3", "Sample4"],
                     "boxpoints": "suspectedoutliers",
                     "marker": {
-                        "color": "#6ddfff",
+                        "color": "#7D8040",
                     },
                     "line": {
-                        "color": "#6ddfff"
+                        "color": "#7D8040"
                     },
-                    "fillcolor": "#6ddfff80",
+                    "fillcolor": "#7D804080",
                     "offsetgroup": "",
-                    "legendgroup": "Assay2 - Sequencer2",
-                    "legend": "Assay2 - Sequencer2",
+                    "legendgroup": "TruSight Oncology 500 - Sequencer2",
+                    "legend": "TruSight Oncology 500 - Sequencer2",
                     "visible": True,
                     "showlegend": True
                 },
@@ -679,7 +676,7 @@ class TestFormatDataForPlotlyJS(TestCase):
                 "sample_id": ["Sample1", "Sample2", "Sample3", "Sample4", "Sample5"],
                 "date": ["2024-06-24", "2024-06-24", "2024-06-24", "2024-06-24", "2024-06-25"],
                 "project_name": ["240624_Project1", "240624_Project1", "240624_Project2", "240624_Project2", "240625_Project3"],
-                "assay": ["Assay1", "Assay1", "Assay2", "Assay2", "Assay1"],
+                "assay": ["TruSight Oncology 500", "TruSight Oncology 500", "Twist WES", "Twist WES", "TruSight Oncology 500"],
                 "sequencer_id": ["Sequencer1", "Sequencer1", "Sequencer2", "Sequencer2", "Sequencer1"],
                 "fastqc__read_data_1st_lane_R1__lane": ["L001", "L001", "L003", "L003", "L001"],
                 "fastqc__read_data_2nd_lane_R1__lane": ["L002", "L002", "L004", "L004", "L002"],
@@ -690,8 +687,6 @@ class TestFormatDataForPlotlyJS(TestCase):
             }
         )
 
-        # set the seed to get expected results
-        random.seed(0)
         test_output = format_data_for_plotly_js(test_input)
         expected_output = (
             json.dumps([
@@ -702,20 +697,20 @@ class TestFormatDataForPlotlyJS(TestCase):
                         ["240624_Project1", "240624_Project1"]
                     ],
                     "y": [7.0, 8.0],
-                    "name": "Assay1 - Sequencer1",
+                    "name": "TruSight Oncology 500 - Sequencer1",
                     "type": "box",
                     "text": ["Sample1", "Sample2"],
                     "boxpoints": "suspectedoutliers",
                     "marker": {
-                        "color": "#6600cc",
+                        "color": "#7D8040",
                     },
                     "line": {
-                        "color": "#6600cc"
+                        "color": "#7D8040"
                     },
-                    "fillcolor": "#6600cc80",
-                    "offsetgroup": "Assay1 - Sequencer1",
-                    "legendgroup": "Assay1 - Sequencer1",
-                    "legend": "Assay1 - Sequencer1",
+                    "fillcolor": "#7D804080",
+                    "offsetgroup": "TruSight Oncology 500 - Sequencer1",
+                    "legendgroup": "TruSight Oncology 500 - Sequencer1",
+                    "legend": "TruSight Oncology 500 - Sequencer1",
                     "visible": True,
                     "showlegend": True
                 },
@@ -774,20 +769,20 @@ class TestFormatDataForPlotlyJS(TestCase):
                         ["240624_Project2", "240624_Project2"]
                     ],
                     "y": [9.0, 10.0],
-                    "name": "Assay2 - Sequencer2",
+                    "name": "Twist WES - Sequencer2",
                     "type": "box",
                     "text": ["Sample3", "Sample4"],
                     "boxpoints": "suspectedoutliers",
                     "marker": {
-                        "color": "#6ddfff",
+                        "color": "#ff65ff",
                     },
                     "line": {
-                        "color": "#6ddfff"
+                        "color": "#ff65ff"
                     },
-                    "fillcolor": "#6ddfff80",
-                    "offsetgroup": "Assay2 - Sequencer2",
-                    "legendgroup": "Assay2 - Sequencer2",
-                    "legend": "Assay2 - Sequencer2",
+                    "fillcolor": "#ff65ff80",
+                    "offsetgroup": "Twist WES - Sequencer2",
+                    "legendgroup": "Twist WES - Sequencer2",
+                    "legend": "Twist WES - Sequencer2",
                     "visible": True,
                     "showlegend": True
                 },
@@ -846,20 +841,20 @@ class TestFormatDataForPlotlyJS(TestCase):
                         ["240625_Project3"]
                     ],
                     "y": [2.0],
-                    "name": "Assay1 - Sequencer1",
+                    "name": "TruSight Oncology 500 - Sequencer1",
                     "type": "box",
                     "text": ["Sample5"],
                     "boxpoints": "suspectedoutliers",
                     "marker": {
-                        "color": "#6600cc",
+                        "color": "#7D8040",
                     },
                     "line": {
-                        "color": "#6600cc"
+                        "color": "#7D8040"
                     },
-                    "fillcolor": "#6600cc80",
-                    "offsetgroup": "Assay1 - Sequencer1",
-                    "legendgroup": "Assay1 - Sequencer1",
-                    "legend": "Assay1 - Sequencer1",
+                    "fillcolor": "#7D804080",
+                    "offsetgroup": "TruSight Oncology 500 - Sequencer1",
+                    "legendgroup": "TruSight Oncology 500 - Sequencer1",
+                    "legend": "TruSight Oncology 500 - Sequencer1",
                     "visible": True,
                     "showlegend": False
                 },
@@ -952,7 +947,7 @@ class TestCreateTrace(TestCase):
                 "sample_id": ["Sample1", "Sample2", "Sample3"],
                 "date": ["2024-06-25", "2024-06-25", "2024-06-25"],
                 "project_name": ["240625_Project1", "240625_Project1", "240625_Project1"],
-                "assay": ["Assay1", "Assay1", "Assay1"],
+                "assay": ["Myeloid", "Myeloid", "Myeloid"],
                 "sequencer_id": ["Sequencer1", "Sequencer1", "Sequencer1"],
                 "metric": [1, 2, 3]
             }
@@ -963,16 +958,14 @@ class TestCreateTrace(TestCase):
             "data_column": "metric",
             "project_name": "240625_Project1",
             "lane": None,
-            "name": "Assay1 - Project1",
-            "boxplot_color": "#6600cc",
-            "boxplot_line_color": "#6600cc",
+            "name": "Myeloid - Project1",
+            "boxplot_color": "#FF7800",
+            "boxplot_line_color": "#FF7800",
             "offsetgroup": "",
-            "legendgroup": "Assay1 - Project1",
+            "legendgroup": "Myeloid - Project1",
             "showlegend": True
         }
 
-        # set the seed to get expected results
-        random.seed(0)
         test_output = create_trace(**test_input)
 
         expected_output = {
@@ -983,13 +976,13 @@ class TestCreateTrace(TestCase):
             "type": "box",
             "text": ["Sample1", "Sample2", "Sample3"],
             "boxpoints": "suspectedoutliers",
-            "marker": {"color": "#6600cc"},
-            "line": {"color": "#6600cc"},
-            "fillcolor": "#6600cc80",
-            "name": "Assay1 - Project1",
+            "marker": {"color": "#FF7800"},
+            "line": {"color": "#FF7800"},
+            "fillcolor": "#FF780080",
+            "name": "Myeloid - Project1",
             "offsetgroup": "",
-            "legendgroup": "Assay1 - Project1",
-            "legend": "Assay1 - Project1",
+            "legendgroup": "Myeloid - Project1",
+            "legend": "Myeloid - Project1",
             "visible": True,
             "showlegend": True
         }

--- a/trendyqc/trend_monitoring/tests/test_views.py
+++ b/trendyqc/trend_monitoring/tests/test_views.py
@@ -4,6 +4,8 @@ from django.test import TestCase
 from unittest.mock import patch
 
 from trend_monitoring.models.filters import Filter
+from trend_monitoring.models.metadata import Report
+from trend_monitoring.tables import ReportTable
 
 
 class TestDashboard(TestCase):
@@ -36,7 +38,7 @@ class TestDashboard(TestCase):
 
         mock_context_data.return_value = {
             "assays": ["CEN", "TSO500"],
-            "tables": [],
+            "tables": [ReportTable(Report.objects.all())],
             "project_names": ["Project1", "Project2"],
             "sequencer_ids": ["Sequencer1", "Sequencer2"],
             "metrics": ["Metric1", "Metric2"]
@@ -127,8 +129,8 @@ class TestDashboard(TestCase):
             self.assertEqual(created_filter_id.content, json.dumps(
                 {
                     'assay_select': ['Cancer Endocrine Neurology'],
-                    'date_start': '2024-08-20',
-                    'date_end': '2024-08-23',
+                    'date_start': ['2024-08-20'],
+                    'date_end': ['2024-08-23'],
                     'metrics_y': ['read_data|avg_length'],
                 }
             ))


### PR DESCRIPTION
- Remove randomness use to choose colors of plots
- Remove potential bug where multiple assay+sequencer combos are used multiple times in the data input i.e. if we have in our input:
    - 240101 `MYE - Seq1`
    - 240102 `TSO - Seq2`
    - 240103 `MYE - Seq1`
    - I believe the color of the 2nd `MYE - Seq1` would have the same color of `TSO - Seq2` in the old version of the code
- Fix weird bug with the GET request for the dashboard doesn't accept an empty `tables` key for the context data
- Fix parsing of date when saving filter

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/trendyQC/137)
<!-- Reviewable:end -->
